### PR TITLE
[feat] 회원가입 기능 구현 및 로그인 응답 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+    implementation 'com.auth0:java-jwt:4.4.0'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/fastcampus/mini9/common/exception/ErrorCode.java
+++ b/src/main/java/com/fastcampus/mini9/common/exception/ErrorCode.java
@@ -12,7 +12,9 @@ public enum ErrorCode {
     NoPermission(401, "noPermission"),
     ImageUploadError(400, "이미지 업로드 중 오류 발생"),
     ImageDeleteError(400, "이미지 삭제 중 오류 발생"),
-    InvalidImageType(400, "유효하지 않은 이미지 형식입니다");
+    InvalidImageType(400, "유효하지 않은 이미지 형식입니다"),
+    ExistsArgument(400, "이미 존재합니다"),
+    ;
 
     private final Integer code;
     private final String msg;

--- a/src/main/java/com/fastcampus/mini9/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/fastcampus/mini9/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.fastcampus.mini9.common.exception;
 
+import com.fastcampus.mini9.common.response.ErrorResponseBody;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -9,8 +10,6 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import com.fastcampus.mini9.common.response.ErrorResponseBody;
-
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -19,9 +18,10 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponseBody> handleException(MethodArgumentNotValidException ex) {
         logger.warn("invalid request", ex);
+        String errorMessage = ex.getBindingResult().getFieldErrors().get(0).getDefaultMessage();
         return ResponseEntity
             .badRequest()
-            .body(new ErrorResponseBody(false, 400, ex.getMessage(), ex));
+            .body(new ErrorResponseBody(false, 400, errorMessage, ex));
     }
 
     @ExceptionHandler(BaseException.class)

--- a/src/main/java/com/fastcampus/mini9/common/util/cookie/CookieUtil.java
+++ b/src/main/java/com/fastcampus/mini9/common/util/cookie/CookieUtil.java
@@ -29,12 +29,13 @@ public class CookieUtil {
         Cookie cookie = new Cookie(name, value);
         cookie.setPath("/");
         cookie.setHttpOnly(true);
+        cookie.setSecure(true);
         cookie.setAttribute("Samesite", "Lax");
         cookie.setMaxAge(maxAge);
         response.addCookie(cookie);
     }
 
-    public static void addCookieWithoutSecure(
+    public static void addCookieWithoutHttp(
         HttpServletResponse response,
         String name,
         String value,
@@ -42,6 +43,8 @@ public class CookieUtil {
     ) {
         Cookie cookie = new Cookie(name, value);
         cookie.setPath("/");
+        cookie.setHttpOnly(false);
+        cookie.setSecure(true);
         cookie.setAttribute("Samesite", "Lax");
         cookie.setMaxAge(maxAge);
         response.addCookie(cookie);

--- a/src/main/java/com/fastcampus/mini9/common/util/cookie/CookieUtil.java
+++ b/src/main/java/com/fastcampus/mini9/common/util/cookie/CookieUtil.java
@@ -1,10 +1,9 @@
 package com.fastcampus.mini9.common.util.cookie;
 
-import java.util.Optional;
-
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Optional;
 
 public class CookieUtil {
 

--- a/src/main/java/com/fastcampus/mini9/common/util/cookie/CookieUtil.java
+++ b/src/main/java/com/fastcampus/mini9/common/util/cookie/CookieUtil.java
@@ -1,10 +1,9 @@
 package com.fastcampus.mini9.common.util.cookie;
 
-import java.util.Optional;
-
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Optional;
 
 public class CookieUtil {
 
@@ -21,13 +20,28 @@ public class CookieUtil {
         return Optional.empty();
     }
 
-    public static void addCookie(HttpServletResponse response, String name, String value,
-                                 int maxAge) {
+    public static void addCookie(
+        HttpServletResponse response,
+        String name,
+        String value,
+        int maxAge
+    ) {
         Cookie cookie = new Cookie(name, value);
         cookie.setPath("/");
-        cookie.setDomain("mwt-market.store");
         cookie.setHttpOnly(true);
-        cookie.setSecure(true);
+        cookie.setAttribute("Samesite", "Lax");
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
+    }
+
+    public static void addCookieWithoutSecure(
+        HttpServletResponse response,
+        String name,
+        String value,
+        int maxAge
+    ) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
         cookie.setAttribute("Samesite", "Lax");
         cookie.setMaxAge(maxAge);
         response.addCookie(cookie);

--- a/src/main/java/com/fastcampus/mini9/config/security/SecurityConfig.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/SecurityConfig.java
@@ -1,0 +1,170 @@
+package com.fastcampus.mini9.config.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationDetailsSource;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.config.annotation.web.configurers.FormLoginConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AnonymousAuthenticationFilter;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
+import org.springframework.security.web.context.NullSecurityContextRepository;
+import org.springframework.security.web.context.SecurityContextRepository;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import com.fastcampus.mini9.config.security.exception.AjaxAuthenticationEntryPoint;
+import com.fastcampus.mini9.config.security.filter.AjaxAuthenticationFilter;
+import com.fastcampus.mini9.config.security.filter.AjaxAuthenticationFilterConfigurer;
+import com.fastcampus.mini9.config.security.filter.JwtAuthenticationFilter;
+import com.fastcampus.mini9.config.security.handler.AjaxAuthenticationFailureHandler;
+import com.fastcampus.mini9.config.security.handler.AjaxAuthenticationSuccessHandler;
+import com.fastcampus.mini9.config.security.provider.AjaxAuthenticationProvider;
+import com.fastcampus.mini9.config.security.provider.JwtProvider;
+import com.fastcampus.mini9.config.security.service.AjaxUserDetailService;
+import com.fastcampus.mini9.config.security.service.RefreshTokenService;
+import com.fastcampus.mini9.config.security.token.AuthenticationDetails;
+import com.fastcampus.mini9.config.security.token.UserPrincipal;
+import com.fastcampus.mini9.domain.member.repository.MemberRepository;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+	@Value("${remote-server.front.url}")
+	private String frontUrl;
+	@Value("${remote-server.gateway.url}")
+	private String gatewayUrl;
+	private String frontUrlLocal = "http://localhost:3000";
+
+	private static final String loginProcUrl = "/login";
+
+	@Autowired
+	private AuthenticationConfiguration authenticationConfiguration;
+	@Autowired
+	private JwtProvider jwtProvider;
+	@Autowired
+	private RefreshTokenService refreshTokenService;
+	@Autowired
+	private MemberRepository memberRepository;
+
+	private static final String[] SWAGGER_PAGE = {
+		"/swagger-ui/**", "/api-docs", "/swagger-ui-custom.html",
+		"/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html"
+	};
+
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		http
+			.httpBasic(HttpBasicConfigurer::disable)
+			.formLogin(FormLoginConfigurer::disable)
+			.csrf(CsrfConfigurer::disable)
+			.sessionManagement(sessionManagementConfigurer -> sessionManagementConfigurer
+				.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.cors(httpSecurityCorsConfigurer -> httpSecurityCorsConfigurer
+				.configurationSource(corsConfigurationSource()));
+
+		http
+			.authorizeHttpRequests((authorizeHttpRequests) -> authorizeHttpRequests
+				.requestMatchers(SWAGGER_PAGE).permitAll()
+				.requestMatchers(AntPathRequestMatcher.antMatcher(HttpMethod.GET, "/products")).permitAll()
+				.anyRequest().permitAll());
+
+		http
+			.apply(
+				new AjaxAuthenticationFilterConfigurer(new AjaxAuthenticationFilter(loginProcUrl), loginProcUrl))
+			.setAuthenticationManager(authenticationManager())
+			.successHandlerAjax(new AjaxAuthenticationSuccessHandler(jwtProvider, refreshTokenService))
+			.failureHandlerAjax(new AjaxAuthenticationFailureHandler())
+			.setAuthenticationDetailsSource(authenticationDetailsSource())
+			.loginProcessingUrl(loginProcUrl);
+
+		http
+			.addFilterBefore(new JwtAuthenticationFilter(authenticationManager(), authenticationDetailsSource()),
+				AnonymousAuthenticationFilter.class);
+
+		http
+			.anonymous((anonymous) -> anonymous
+				.principal(new UserPrincipal(null, "anonymous")));
+
+		http
+			.exceptionHandling((exceptionHandling) -> exceptionHandling
+				.authenticationEntryPoint(new AjaxAuthenticationEntryPoint()));
+
+		http
+			.headers(httpSecurityHeadersConfigurer -> httpSecurityHeadersConfigurer
+				.frameOptions(FrameOptionsConfig::sameOrigin));
+
+		return http.build();
+	}
+
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration corsConfiguration = new CorsConfiguration();
+
+		corsConfiguration.addAllowedOriginPattern("*");
+		//        corsConfiguration.addAllowedOrigin(frontUrl);
+		//        corsConfiguration.addAllowedOrigin(gatewayUrl);
+		//        corsConfiguration.addAllowedOrigin(frontUrlLocal);
+		corsConfiguration.addAllowedHeader("*");
+		corsConfiguration.addAllowedMethod("*");
+		corsConfiguration.setAllowCredentials(true);
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", corsConfiguration);
+
+		return source;
+	}
+
+	@Bean
+	public SecurityContextRepository securityContextRepository() {
+		return new NullSecurityContextRepository();
+	}
+
+	@Bean
+	public AuthenticationManager authenticationManager() throws Exception {
+		return authenticationConfiguration.getAuthenticationManager();
+	}
+
+	@Bean
+	public AuthenticationDetailsSource<HttpServletRequest,
+		WebAuthenticationDetails> authenticationDetailsSource() {
+		return context -> new AuthenticationDetails(context);
+	}
+
+	@Bean
+	public AjaxAuthenticationProvider authenticationProvider(AuthenticationManagerBuilder auth,
+		JwtProvider jwtProvider) {
+		AjaxAuthenticationProvider ajaxAuthenticationProvider = new AjaxAuthenticationProvider(
+			ajaxUserDetailService(), passwordEncoder());
+		auth.authenticationProvider(ajaxAuthenticationProvider).authenticationProvider(jwtProvider);
+		return ajaxAuthenticationProvider;
+	}
+
+	@Bean
+	public AjaxUserDetailService ajaxUserDetailService() {
+		return new AjaxUserDetailService(memberRepository);
+	}
+
+	@Bean
+	public static PasswordEncoder passwordEncoder() {
+		return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+	}
+}

--- a/src/main/java/com/fastcampus/mini9/config/security/SecurityConfig.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/SecurityConfig.java
@@ -1,5 +1,21 @@
 package com.fastcampus.mini9.config.security;
 
+import com.fastcampus.mini9.config.security.exception.AjaxAuthenticationEntryPoint;
+import com.fastcampus.mini9.config.security.filter.AjaxAuthenticationFilter;
+import com.fastcampus.mini9.config.security.filter.AjaxAuthenticationFilterConfigurer;
+import com.fastcampus.mini9.config.security.filter.JwtAuthenticationFilter;
+import com.fastcampus.mini9.config.security.handler.AjaxAuthenticationFailureHandler;
+import com.fastcampus.mini9.config.security.handler.AjaxAuthenticationSuccessHandler;
+import com.fastcampus.mini9.config.security.handler.JwtLogoutHandler;
+import com.fastcampus.mini9.config.security.handler.JwtLogoutSuccessHandler;
+import com.fastcampus.mini9.config.security.provider.AjaxAuthenticationProvider;
+import com.fastcampus.mini9.config.security.provider.JwtProvider;
+import com.fastcampus.mini9.config.security.service.AjaxUserDetailService;
+import com.fastcampus.mini9.config.security.service.RefreshTokenService;
+import com.fastcampus.mini9.config.security.token.AuthenticationDetails;
+import com.fastcampus.mini9.config.security.token.UserPrincipal;
+import com.fastcampus.mini9.domain.member.repository.MemberRepository;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -28,151 +44,134 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import com.fastcampus.mini9.config.security.exception.AjaxAuthenticationEntryPoint;
-import com.fastcampus.mini9.config.security.filter.AjaxAuthenticationFilter;
-import com.fastcampus.mini9.config.security.filter.AjaxAuthenticationFilterConfigurer;
-import com.fastcampus.mini9.config.security.filter.JwtAuthenticationFilter;
-import com.fastcampus.mini9.config.security.handler.AjaxAuthenticationFailureHandler;
-import com.fastcampus.mini9.config.security.handler.AjaxAuthenticationSuccessHandler;
-import com.fastcampus.mini9.config.security.handler.JwtLogoutHandler;
-import com.fastcampus.mini9.config.security.handler.JwtLogoutSuccessHandler;
-import com.fastcampus.mini9.config.security.provider.AjaxAuthenticationProvider;
-import com.fastcampus.mini9.config.security.provider.JwtProvider;
-import com.fastcampus.mini9.config.security.service.AjaxUserDetailService;
-import com.fastcampus.mini9.config.security.service.RefreshTokenService;
-import com.fastcampus.mini9.config.security.token.AuthenticationDetails;
-import com.fastcampus.mini9.config.security.token.UserPrincipal;
-import com.fastcampus.mini9.domain.member.repository.MemberRepository;
-
-import jakarta.servlet.http.HttpServletRequest;
-
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
-	@Value("${remote-server.front.url}")
-	private String frontUrl;
-	@Value("${remote-server.gateway.url}")
-	private String gatewayUrl;
-	private String frontUrlLocal = "http://localhost:3000";
+    private static final String loginProcUrl = "/login";
+    private static final String[] SWAGGER_PAGE = {
+        "/swagger-ui/**", "/api-docs", "/swagger-ui-custom.html",
+        "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html"
+    };
+    @Value("${remote-server.front.url}")
+    private String frontUrl;
+    @Value("${remote-server.gateway.url}")
+    private String gatewayUrl;
+    private String frontUrlLocal = "http://localhost:3000";
+    @Autowired
+    private AuthenticationConfiguration authenticationConfiguration;
+    @Autowired
+    private JwtProvider jwtProvider;
+    @Autowired
+    private RefreshTokenService refreshTokenService;
+    @Autowired
+    private MemberRepository memberRepository;
 
-	private static final String loginProcUrl = "/login";
+    @Bean
+    public static PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
 
-	@Autowired
-	private AuthenticationConfiguration authenticationConfiguration;
-	@Autowired
-	private JwtProvider jwtProvider;
-	@Autowired
-	private RefreshTokenService refreshTokenService;
-	@Autowired
-	private MemberRepository memberRepository;
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .httpBasic(HttpBasicConfigurer::disable)
+            .formLogin(FormLoginConfigurer::disable)
+            .csrf(CsrfConfigurer::disable)
+            .sessionManagement(sessionManagementConfigurer -> sessionManagementConfigurer
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .cors(httpSecurityCorsConfigurer -> httpSecurityCorsConfigurer
+                .configurationSource(corsConfigurationSource()));
 
-	private static final String[] SWAGGER_PAGE = {
-		"/swagger-ui/**", "/api-docs", "/swagger-ui-custom.html",
-		"/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html"
-	};
+        http
+            .authorizeHttpRequests((authorizeHttpRequests) -> authorizeHttpRequests
+                .requestMatchers(SWAGGER_PAGE).permitAll()
+                .requestMatchers(AntPathRequestMatcher.antMatcher(HttpMethod.GET, "/products"))
+                .permitAll()
+                .anyRequest().permitAll());
 
-	@Bean
-	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-		http
-			.httpBasic(HttpBasicConfigurer::disable)
-			.formLogin(FormLoginConfigurer::disable)
-			.csrf(CsrfConfigurer::disable)
-			.sessionManagement(sessionManagementConfigurer -> sessionManagementConfigurer
-				.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-			.cors(httpSecurityCorsConfigurer -> httpSecurityCorsConfigurer
-				.configurationSource(corsConfigurationSource()));
+        http
+            .logout((logout) -> logout
+                .logoutUrl("/logout")
+                .addLogoutHandler(new JwtLogoutHandler())
+                .logoutSuccessHandler(new JwtLogoutSuccessHandler()));
 
-		http
-			.authorizeHttpRequests((authorizeHttpRequests) -> authorizeHttpRequests
-				.requestMatchers(SWAGGER_PAGE).permitAll()
-				.requestMatchers(AntPathRequestMatcher.antMatcher(HttpMethod.GET, "/products")).permitAll()
-				.anyRequest().permitAll());
+        http
+            .apply(
+                new AjaxAuthenticationFilterConfigurer(new AjaxAuthenticationFilter(loginProcUrl),
+                    loginProcUrl))
+            .setAuthenticationManager(authenticationManager())
+            .successHandlerAjax(
+                new AjaxAuthenticationSuccessHandler(jwtProvider, refreshTokenService))
+            .failureHandlerAjax(new AjaxAuthenticationFailureHandler())
+            .setAuthenticationDetailsSource(authenticationDetailsSource())
+            .loginProcessingUrl(loginProcUrl);
 
-		http
-			.logout((logout) -> logout
-				.logoutUrl("/logout")
-				.addLogoutHandler(new JwtLogoutHandler())
-				.logoutSuccessHandler(new JwtLogoutSuccessHandler()));
+        http
+            .addFilterBefore(
+                new JwtAuthenticationFilter(authenticationManager(), authenticationDetailsSource()),
+                AnonymousAuthenticationFilter.class);
 
-		http
-			.apply(
-				new AjaxAuthenticationFilterConfigurer(new AjaxAuthenticationFilter(loginProcUrl), loginProcUrl))
-			.setAuthenticationManager(authenticationManager())
-			.successHandlerAjax(new AjaxAuthenticationSuccessHandler(jwtProvider, refreshTokenService))
-			.failureHandlerAjax(new AjaxAuthenticationFailureHandler())
-			.setAuthenticationDetailsSource(authenticationDetailsSource())
-			.loginProcessingUrl(loginProcUrl);
+        http
+            .anonymous((anonymous) -> anonymous
+                .principal(new UserPrincipal(null, "anonymous")));
 
-		http
-			.addFilterBefore(new JwtAuthenticationFilter(authenticationManager(), authenticationDetailsSource()),
-				AnonymousAuthenticationFilter.class);
+        http
+            .exceptionHandling((exceptionHandling) -> exceptionHandling
+                .authenticationEntryPoint(new AjaxAuthenticationEntryPoint()));
 
-		http
-			.anonymous((anonymous) -> anonymous
-				.principal(new UserPrincipal(null, "anonymous")));
+        http
+            .headers(httpSecurityHeadersConfigurer -> httpSecurityHeadersConfigurer
+                .frameOptions(FrameOptionsConfig::sameOrigin));
 
-		http
-			.exceptionHandling((exceptionHandling) -> exceptionHandling
-				.authenticationEntryPoint(new AjaxAuthenticationEntryPoint()));
+        return http.build();
+    }
 
-		http
-			.headers(httpSecurityHeadersConfigurer -> httpSecurityHeadersConfigurer
-				.frameOptions(FrameOptionsConfig::sameOrigin));
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration corsConfiguration = new CorsConfiguration();
 
-		return http.build();
-	}
+        corsConfiguration.addAllowedOriginPattern("*");
+        //        corsConfiguration.addAllowedOrigin(frontUrl);
+        //        corsConfiguration.addAllowedOrigin(gatewayUrl);
+        //        corsConfiguration.addAllowedOrigin(frontUrlLocal);
+        corsConfiguration.addAllowedHeader("*");
+        corsConfiguration.addAllowedMethod("*");
+        corsConfiguration.setAllowCredentials(true);
 
-	@Bean
-	public CorsConfigurationSource corsConfigurationSource() {
-		CorsConfiguration corsConfiguration = new CorsConfiguration();
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", corsConfiguration);
 
-		corsConfiguration.addAllowedOriginPattern("*");
-		//        corsConfiguration.addAllowedOrigin(frontUrl);
-		//        corsConfiguration.addAllowedOrigin(gatewayUrl);
-		//        corsConfiguration.addAllowedOrigin(frontUrlLocal);
-		corsConfiguration.addAllowedHeader("*");
-		corsConfiguration.addAllowedMethod("*");
-		corsConfiguration.setAllowCredentials(true);
+        return source;
+    }
 
-		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-		source.registerCorsConfiguration("/**", corsConfiguration);
+    @Bean
+    public SecurityContextRepository securityContextRepository() {
+        return new NullSecurityContextRepository();
+    }
 
-		return source;
-	}
+    @Bean
+    public AuthenticationManager authenticationManager() throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
 
-	@Bean
-	public SecurityContextRepository securityContextRepository() {
-		return new NullSecurityContextRepository();
-	}
+    @Bean
+    public AuthenticationDetailsSource<HttpServletRequest,
+        WebAuthenticationDetails> authenticationDetailsSource() {
+        return context -> new AuthenticationDetails(context);
+    }
 
-	@Bean
-	public AuthenticationManager authenticationManager() throws Exception {
-		return authenticationConfiguration.getAuthenticationManager();
-	}
+    @Bean
+    public AjaxAuthenticationProvider authenticationProvider(AuthenticationManagerBuilder auth,
+                                                             JwtProvider jwtProvider) {
+        AjaxAuthenticationProvider ajaxAuthenticationProvider = new AjaxAuthenticationProvider(
+            ajaxUserDetailService(), passwordEncoder());
+        auth.authenticationProvider(ajaxAuthenticationProvider).authenticationProvider(jwtProvider);
+        return ajaxAuthenticationProvider;
+    }
 
-	@Bean
-	public AuthenticationDetailsSource<HttpServletRequest,
-		WebAuthenticationDetails> authenticationDetailsSource() {
-		return context -> new AuthenticationDetails(context);
-	}
-
-	@Bean
-	public AjaxAuthenticationProvider authenticationProvider(AuthenticationManagerBuilder auth,
-		JwtProvider jwtProvider) {
-		AjaxAuthenticationProvider ajaxAuthenticationProvider = new AjaxAuthenticationProvider(
-			ajaxUserDetailService(), passwordEncoder());
-		auth.authenticationProvider(ajaxAuthenticationProvider).authenticationProvider(jwtProvider);
-		return ajaxAuthenticationProvider;
-	}
-
-	@Bean
-	public AjaxUserDetailService ajaxUserDetailService() {
-		return new AjaxUserDetailService(memberRepository);
-	}
-
-	@Bean
-	public static PasswordEncoder passwordEncoder() {
-		return PasswordEncoderFactories.createDelegatingPasswordEncoder();
-	}
+    @Bean
+    public AjaxUserDetailService ajaxUserDetailService() {
+        return new AjaxUserDetailService(memberRepository);
+    }
 }

--- a/src/main/java/com/fastcampus/mini9/config/security/SecurityConfig.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/SecurityConfig.java
@@ -54,7 +54,7 @@ public class SecurityConfig {
 	private String gatewayUrl;
 	private String frontUrlLocal = "http://localhost:3000";
 
-	private static final String loginProcUrl = "/login";
+	private static final String loginProcUrl = "/api/login";
 
 	@Autowired
 	private AuthenticationConfiguration authenticationConfiguration;
@@ -84,9 +84,11 @@ public class SecurityConfig {
 		http
 			.authorizeHttpRequests((authorizeHttpRequests) -> authorizeHttpRequests
 				.requestMatchers(SWAGGER_PAGE).permitAll()
-				.requestMatchers(AntPathRequestMatcher.antMatcher(HttpMethod.GET, "/products")).permitAll()
-				.anyRequest().permitAll());
-
+				.requestMatchers("/error/**").permitAll()
+//				.requestMatchers(AntPathRequestMatcher.antMatcher(HttpMethod.GET, "/products")).permitAll()
+				.requestMatchers("/api/login").permitAll()
+				.requestMatchers("/api/sign-up").permitAll()
+				.anyRequest().authenticated());
 		http
 			.apply(
 				new AjaxAuthenticationFilterConfigurer(new AjaxAuthenticationFilter(loginProcUrl), loginProcUrl))

--- a/src/main/java/com/fastcampus/mini9/config/security/SecurityConfig.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/SecurityConfig.java
@@ -1,5 +1,19 @@
 package com.fastcampus.mini9.config.security;
 
+import com.fastcampus.mini9.config.security.exception.AjaxAuthenticationEntryPoint;
+import com.fastcampus.mini9.config.security.filter.AjaxAuthenticationFilter;
+import com.fastcampus.mini9.config.security.filter.AjaxAuthenticationFilterConfigurer;
+import com.fastcampus.mini9.config.security.filter.JwtAuthenticationFilter;
+import com.fastcampus.mini9.config.security.handler.AjaxAuthenticationFailureHandler;
+import com.fastcampus.mini9.config.security.handler.AjaxAuthenticationSuccessHandler;
+import com.fastcampus.mini9.config.security.provider.AjaxAuthenticationProvider;
+import com.fastcampus.mini9.config.security.provider.JwtProvider;
+import com.fastcampus.mini9.config.security.service.AjaxUserDetailService;
+import com.fastcampus.mini9.config.security.service.RefreshTokenService;
+import com.fastcampus.mini9.config.security.token.AuthenticationDetails;
+import com.fastcampus.mini9.config.security.token.UserPrincipal;
+import com.fastcampus.mini9.domain.member.repository.MemberRepository;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -28,143 +42,128 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import com.fastcampus.mini9.config.security.exception.AjaxAuthenticationEntryPoint;
-import com.fastcampus.mini9.config.security.filter.AjaxAuthenticationFilter;
-import com.fastcampus.mini9.config.security.filter.AjaxAuthenticationFilterConfigurer;
-import com.fastcampus.mini9.config.security.filter.JwtAuthenticationFilter;
-import com.fastcampus.mini9.config.security.handler.AjaxAuthenticationFailureHandler;
-import com.fastcampus.mini9.config.security.handler.AjaxAuthenticationSuccessHandler;
-import com.fastcampus.mini9.config.security.provider.AjaxAuthenticationProvider;
-import com.fastcampus.mini9.config.security.provider.JwtProvider;
-import com.fastcampus.mini9.config.security.service.AjaxUserDetailService;
-import com.fastcampus.mini9.config.security.service.RefreshTokenService;
-import com.fastcampus.mini9.config.security.token.AuthenticationDetails;
-import com.fastcampus.mini9.config.security.token.UserPrincipal;
-import com.fastcampus.mini9.domain.member.repository.MemberRepository;
-
-import jakarta.servlet.http.HttpServletRequest;
-
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
-	@Value("${remote-server.front.url}")
-	private String frontUrl;
-	@Value("${remote-server.gateway.url}")
-	private String gatewayUrl;
-	private String frontUrlLocal = "http://localhost:3000";
+    private static final String loginProcUrl = "/login";
+    private static final String[] SWAGGER_PAGE = {
+        "/swagger-ui/**", "/api-docs", "/swagger-ui-custom.html",
+        "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html"
+    };
+    @Value("${remote-server.front.url}")
+    private String frontUrl;
+    @Value("${remote-server.gateway.url}")
+    private String gatewayUrl;
+    private String frontUrlLocal = "http://localhost:3000";
+    @Autowired
+    private AuthenticationConfiguration authenticationConfiguration;
+    @Autowired
+    private JwtProvider jwtProvider;
+    @Autowired
+    private RefreshTokenService refreshTokenService;
+    @Autowired
+    private MemberRepository memberRepository;
 
-	private static final String loginProcUrl = "/login";
+    @Bean
+    public static PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
 
-	@Autowired
-	private AuthenticationConfiguration authenticationConfiguration;
-	@Autowired
-	private JwtProvider jwtProvider;
-	@Autowired
-	private RefreshTokenService refreshTokenService;
-	@Autowired
-	private MemberRepository memberRepository;
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .httpBasic(HttpBasicConfigurer::disable)
+            .formLogin(FormLoginConfigurer::disable)
+            .csrf(CsrfConfigurer::disable)
+            .sessionManagement(sessionManagementConfigurer -> sessionManagementConfigurer
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .cors(httpSecurityCorsConfigurer -> httpSecurityCorsConfigurer
+                .configurationSource(corsConfigurationSource()));
 
-	private static final String[] SWAGGER_PAGE = {
-		"/swagger-ui/**", "/api-docs", "/swagger-ui-custom.html",
-		"/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html"
-	};
+        http
+            .authorizeHttpRequests((authorizeHttpRequests) -> authorizeHttpRequests
+                .requestMatchers(SWAGGER_PAGE).permitAll()
+                .requestMatchers(AntPathRequestMatcher.antMatcher(HttpMethod.GET, "/products"))
+                .permitAll()
+                .anyRequest().permitAll());
 
-	@Bean
-	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-		http
-			.httpBasic(HttpBasicConfigurer::disable)
-			.formLogin(FormLoginConfigurer::disable)
-			.csrf(CsrfConfigurer::disable)
-			.sessionManagement(sessionManagementConfigurer -> sessionManagementConfigurer
-				.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-			.cors(httpSecurityCorsConfigurer -> httpSecurityCorsConfigurer
-				.configurationSource(corsConfigurationSource()));
+        http
+            .apply(
+                new AjaxAuthenticationFilterConfigurer(new AjaxAuthenticationFilter(loginProcUrl),
+                    loginProcUrl))
+            .setAuthenticationManager(authenticationManager())
+            .successHandlerAjax(
+                new AjaxAuthenticationSuccessHandler(jwtProvider, refreshTokenService))
+            .failureHandlerAjax(new AjaxAuthenticationFailureHandler())
+            .setAuthenticationDetailsSource(authenticationDetailsSource())
+            .loginProcessingUrl(loginProcUrl);
 
-		http
-			.authorizeHttpRequests((authorizeHttpRequests) -> authorizeHttpRequests
-				.requestMatchers(SWAGGER_PAGE).permitAll()
-				.requestMatchers(AntPathRequestMatcher.antMatcher(HttpMethod.GET, "/products")).permitAll()
-				.anyRequest().permitAll());
+        http
+            .addFilterBefore(
+                new JwtAuthenticationFilter(authenticationManager(), authenticationDetailsSource()),
+                AnonymousAuthenticationFilter.class);
 
-		http
-			.apply(
-				new AjaxAuthenticationFilterConfigurer(new AjaxAuthenticationFilter(loginProcUrl), loginProcUrl))
-			.setAuthenticationManager(authenticationManager())
-			.successHandlerAjax(new AjaxAuthenticationSuccessHandler(jwtProvider, refreshTokenService))
-			.failureHandlerAjax(new AjaxAuthenticationFailureHandler())
-			.setAuthenticationDetailsSource(authenticationDetailsSource())
-			.loginProcessingUrl(loginProcUrl);
+        http
+            .anonymous((anonymous) -> anonymous
+                .principal(new UserPrincipal(null, "anonymous")));
 
-		http
-			.addFilterBefore(new JwtAuthenticationFilter(authenticationManager(), authenticationDetailsSource()),
-				AnonymousAuthenticationFilter.class);
+        http
+            .exceptionHandling((exceptionHandling) -> exceptionHandling
+                .authenticationEntryPoint(new AjaxAuthenticationEntryPoint()));
 
-		http
-			.anonymous((anonymous) -> anonymous
-				.principal(new UserPrincipal(null, "anonymous")));
+        http
+            .headers(httpSecurityHeadersConfigurer -> httpSecurityHeadersConfigurer
+                .frameOptions(FrameOptionsConfig::sameOrigin));
 
-		http
-			.exceptionHandling((exceptionHandling) -> exceptionHandling
-				.authenticationEntryPoint(new AjaxAuthenticationEntryPoint()));
+        return http.build();
+    }
 
-		http
-			.headers(httpSecurityHeadersConfigurer -> httpSecurityHeadersConfigurer
-				.frameOptions(FrameOptionsConfig::sameOrigin));
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration corsConfiguration = new CorsConfiguration();
 
-		return http.build();
-	}
+        corsConfiguration.addAllowedOriginPattern("*");
+        //        corsConfiguration.addAllowedOrigin(frontUrl);
+        //        corsConfiguration.addAllowedOrigin(gatewayUrl);
+        //        corsConfiguration.addAllowedOrigin(frontUrlLocal);
+        corsConfiguration.addAllowedHeader("*");
+        corsConfiguration.addAllowedMethod("*");
+        corsConfiguration.setAllowCredentials(true);
 
-	@Bean
-	public CorsConfigurationSource corsConfigurationSource() {
-		CorsConfiguration corsConfiguration = new CorsConfiguration();
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", corsConfiguration);
 
-		corsConfiguration.addAllowedOriginPattern("*");
-		//        corsConfiguration.addAllowedOrigin(frontUrl);
-		//        corsConfiguration.addAllowedOrigin(gatewayUrl);
-		//        corsConfiguration.addAllowedOrigin(frontUrlLocal);
-		corsConfiguration.addAllowedHeader("*");
-		corsConfiguration.addAllowedMethod("*");
-		corsConfiguration.setAllowCredentials(true);
+        return source;
+    }
 
-		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-		source.registerCorsConfiguration("/**", corsConfiguration);
+    @Bean
+    public SecurityContextRepository securityContextRepository() {
+        return new NullSecurityContextRepository();
+    }
 
-		return source;
-	}
+    @Bean
+    public AuthenticationManager authenticationManager() throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
 
-	@Bean
-	public SecurityContextRepository securityContextRepository() {
-		return new NullSecurityContextRepository();
-	}
+    @Bean
+    public AuthenticationDetailsSource<HttpServletRequest,
+        WebAuthenticationDetails> authenticationDetailsSource() {
+        return context -> new AuthenticationDetails(context);
+    }
 
-	@Bean
-	public AuthenticationManager authenticationManager() throws Exception {
-		return authenticationConfiguration.getAuthenticationManager();
-	}
+    @Bean
+    public AjaxAuthenticationProvider authenticationProvider(AuthenticationManagerBuilder auth,
+                                                             JwtProvider jwtProvider) {
+        AjaxAuthenticationProvider ajaxAuthenticationProvider = new AjaxAuthenticationProvider(
+            ajaxUserDetailService(), passwordEncoder());
+        auth.authenticationProvider(ajaxAuthenticationProvider).authenticationProvider(jwtProvider);
+        return ajaxAuthenticationProvider;
+    }
 
-	@Bean
-	public AuthenticationDetailsSource<HttpServletRequest,
-		WebAuthenticationDetails> authenticationDetailsSource() {
-		return context -> new AuthenticationDetails(context);
-	}
-
-	@Bean
-	public AjaxAuthenticationProvider authenticationProvider(AuthenticationManagerBuilder auth,
-		JwtProvider jwtProvider) {
-		AjaxAuthenticationProvider ajaxAuthenticationProvider = new AjaxAuthenticationProvider(
-			ajaxUserDetailService(), passwordEncoder());
-		auth.authenticationProvider(ajaxAuthenticationProvider).authenticationProvider(jwtProvider);
-		return ajaxAuthenticationProvider;
-	}
-
-	@Bean
-	public AjaxUserDetailService ajaxUserDetailService() {
-		return new AjaxUserDetailService(memberRepository);
-	}
-
-	@Bean
-	public static PasswordEncoder passwordEncoder() {
-		return PasswordEncoderFactories.createDelegatingPasswordEncoder();
-	}
+    @Bean
+    public AjaxUserDetailService ajaxUserDetailService() {
+        return new AjaxUserDetailService(memberRepository);
+    }
 }

--- a/src/main/java/com/fastcampus/mini9/config/security/SecurityConfig.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/SecurityConfig.java
@@ -54,7 +54,7 @@ public class SecurityConfig {
 	private String gatewayUrl;
 	private String frontUrlLocal = "http://localhost:3000";
 
-	private static final String loginProcUrl = "/login";
+	private static final String loginProcUrl = "/api/login";
 
 	@Autowired
 	private AuthenticationConfiguration authenticationConfiguration;
@@ -84,8 +84,11 @@ public class SecurityConfig {
 		http
 			.authorizeHttpRequests((authorizeHttpRequests) -> authorizeHttpRequests
 				.requestMatchers(SWAGGER_PAGE).permitAll()
-				.requestMatchers(AntPathRequestMatcher.antMatcher(HttpMethod.GET, "/products")).permitAll()
-				.anyRequest().permitAll());
+				.requestMatchers("/error/**").permitAll()
+//				.requestMatchers(AntPathRequestMatcher.antMatcher(HttpMethod.GET, "/products")).permitAll()
+				.requestMatchers("/api/login").permitAll()
+				.requestMatchers("/api/sign-up").permitAll()
+				.anyRequest().authenticated());
 
 		http
 			.apply(

--- a/src/main/java/com/fastcampus/mini9/config/security/SecurityConfig.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/SecurityConfig.java
@@ -34,6 +34,8 @@ import com.fastcampus.mini9.config.security.filter.AjaxAuthenticationFilterConfi
 import com.fastcampus.mini9.config.security.filter.JwtAuthenticationFilter;
 import com.fastcampus.mini9.config.security.handler.AjaxAuthenticationFailureHandler;
 import com.fastcampus.mini9.config.security.handler.AjaxAuthenticationSuccessHandler;
+import com.fastcampus.mini9.config.security.handler.JwtLogoutHandler;
+import com.fastcampus.mini9.config.security.handler.JwtLogoutSuccessHandler;
 import com.fastcampus.mini9.config.security.provider.AjaxAuthenticationProvider;
 import com.fastcampus.mini9.config.security.provider.JwtProvider;
 import com.fastcampus.mini9.config.security.service.AjaxUserDetailService;
@@ -86,6 +88,12 @@ public class SecurityConfig {
 				.requestMatchers(SWAGGER_PAGE).permitAll()
 				.requestMatchers(AntPathRequestMatcher.antMatcher(HttpMethod.GET, "/products")).permitAll()
 				.anyRequest().permitAll());
+
+		http
+			.logout((logout) -> logout
+				.logoutUrl("/logout")
+				.addLogoutHandler(new JwtLogoutHandler())
+				.logoutSuccessHandler(new JwtLogoutSuccessHandler()));
 
 		http
 			.apply(

--- a/src/main/java/com/fastcampus/mini9/config/security/exception/AjaxAuthenticationEntryPoint.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/exception/AjaxAuthenticationEntryPoint.java
@@ -1,18 +1,15 @@
 package com.fastcampus.mini9.config.security.exception;
 
+import com.fastcampus.mini9.common.response.ErrorResponseBody;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
-
-import com.fastcampus.mini9.common.response.ErrorResponseBody;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 
 public class AjaxAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
@@ -20,7 +17,8 @@ public class AjaxAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
-        AuthenticationException authException) throws IOException, ServletException {
+                         AuthenticationException authException)
+        throws IOException, ServletException {
         response.setStatus(HttpStatus.UNAUTHORIZED.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");

--- a/src/main/java/com/fastcampus/mini9/config/security/exception/AjaxAuthenticationEntryPoint.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/exception/AjaxAuthenticationEntryPoint.java
@@ -1,0 +1,30 @@
+package com.fastcampus.mini9.config.security.exception;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import com.fastcampus.mini9.common.response.ErrorResponseBody;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class AjaxAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException authException) throws IOException, ServletException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(response.getWriter(),
+            ErrorResponseBody.unsuccessful(401, "Unauthorized"));
+    }
+}

--- a/src/main/java/com/fastcampus/mini9/config/security/exception/InvalidJwtException.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/exception/InvalidJwtException.java
@@ -1,0 +1,14 @@
+package com.fastcampus.mini9.config.security.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class InvalidJwtException extends AuthenticationException {
+
+    public InvalidJwtException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+
+    public InvalidJwtException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/com/fastcampus/mini9/config/security/exception/RefreshTokenException.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/exception/RefreshTokenException.java
@@ -1,0 +1,14 @@
+package com.fastcampus.mini9.config.security.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class RefreshTokenException extends AuthenticationException {
+
+    public RefreshTokenException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+
+    public RefreshTokenException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/com/fastcampus/mini9/config/security/filter/AjaxAuthenticationFilter.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/filter/AjaxAuthenticationFilter.java
@@ -1,47 +1,47 @@
 package com.fastcampus.mini9.config.security.filter;
 
+import com.fastcampus.mini9.config.security.token.AjaxAuthenticationToken;
+import com.fastcampus.mini9.domain.member.controller.dto.request.LoginRequestDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
 import org.springframework.util.StringUtils;
 
-import com.fastcampus.mini9.config.security.token.AjaxAuthenticationToken;
-import com.fastcampus.mini9.domain.member.controller.dto.request.LoginRequestDto;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-
 public class AjaxAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
 
-	private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
-	public AjaxAuthenticationFilter(String defaultFilterProcessesUrl) {
-		super(defaultFilterProcessesUrl);
-	}
+    public AjaxAuthenticationFilter(String defaultFilterProcessesUrl) {
+        super(defaultFilterProcessesUrl);
+    }
 
-	@Override
-	public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws
-		AuthenticationException, IOException, ServletException {
-		//boolean isAjax = "XMLHttpRequest".equals(request.getHeader("X-Requested-With"));
-		//if (!isAjax) {
-		//    throw new IllegalStateException("Authentication is not supported");
-		//}
-		LoginRequestDto loginRequestDto = objectMapper.readValue(request.getReader(), LoginRequestDto.class);
-		if (!StringUtils.hasText(loginRequestDto.email()) || !StringUtils.hasText(loginRequestDto.password())) {
-			throw new UsernameNotFoundException("Username Or Password is Empty");
-		}
-		AjaxAuthenticationToken authRequest = AjaxAuthenticationToken
-			.unauthenticated(loginRequestDto.email(), loginRequestDto.password());
-		setDetails(request, authRequest);
-		return getAuthenticationManager().authenticate(authRequest);
-	}
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request,
+                                                HttpServletResponse response) throws
+        AuthenticationException, IOException, ServletException {
+        //boolean isAjax = "XMLHttpRequest".equals(request.getHeader("X-Requested-With"));
+        //if (!isAjax) {
+        //    throw new IllegalStateException("Authentication is not supported");
+        //}
+        LoginRequestDto loginRequestDto =
+            objectMapper.readValue(request.getReader(), LoginRequestDto.class);
+        if (!StringUtils.hasText(loginRequestDto.email()) ||
+            !StringUtils.hasText(loginRequestDto.password())) {
+            throw new UsernameNotFoundException("Username Or Password is Empty");
+        }
+        AjaxAuthenticationToken authRequest = AjaxAuthenticationToken
+            .unauthenticated(loginRequestDto.email(), loginRequestDto.password());
+        setDetails(request, authRequest);
+        return getAuthenticationManager().authenticate(authRequest);
+    }
 
-	protected void setDetails(HttpServletRequest request, AjaxAuthenticationToken authRequest) {
-		authRequest.setDetails(this.authenticationDetailsSource.buildDetails(request));
-	}
+    protected void setDetails(HttpServletRequest request, AjaxAuthenticationToken authRequest) {
+        authRequest.setDetails(this.authenticationDetailsSource.buildDetails(request));
+    }
 }

--- a/src/main/java/com/fastcampus/mini9/config/security/filter/AjaxAuthenticationFilter.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/filter/AjaxAuthenticationFilter.java
@@ -1,20 +1,17 @@
 package com.fastcampus.mini9.config.security.filter;
 
+import com.fastcampus.mini9.config.security.token.AjaxAuthenticationToken;
+import com.fastcampus.mini9.domain.member.controller.dto.request.LoginRequestDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
 import org.springframework.util.StringUtils;
-
-import com.fastcampus.mini9.config.security.token.AjaxAuthenticationToken;
-import com.fastcampus.mini9.domain.member.controller.dto.request.LoginRequestDto;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 
 public class AjaxAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
 
@@ -32,11 +29,11 @@ public class AjaxAuthenticationFilter extends AbstractAuthenticationProcessingFi
 		//    throw new IllegalStateException("Authentication is not supported");
 		//}
 		LoginRequestDto loginRequestDto = objectMapper.readValue(request.getReader(), LoginRequestDto.class);
-		if (!StringUtils.hasText(loginRequestDto.email()) || !StringUtils.hasText(loginRequestDto.password())) {
+		if (!StringUtils.hasText(loginRequestDto.email()) || !StringUtils.hasText(loginRequestDto.pwd())) {
 			throw new UsernameNotFoundException("Username Or Password is Empty");
 		}
 		AjaxAuthenticationToken authRequest = AjaxAuthenticationToken
-			.unauthenticated(loginRequestDto.email(), loginRequestDto.password());
+			.unauthenticated(loginRequestDto.email(), loginRequestDto.pwd());
 		setDetails(request, authRequest);
 		return getAuthenticationManager().authenticate(authRequest);
 	}

--- a/src/main/java/com/fastcampus/mini9/config/security/filter/AjaxAuthenticationFilter.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/filter/AjaxAuthenticationFilter.java
@@ -1,0 +1,47 @@
+package com.fastcampus.mini9.config.security.filter;
+
+import java.io.IOException;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.util.StringUtils;
+
+import com.fastcampus.mini9.config.security.token.AjaxAuthenticationToken;
+import com.fastcampus.mini9.domain.member.controller.dto.request.LoginRequestDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class AjaxAuthenticationFilter extends AbstractAuthenticationProcessingFilter {
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	public AjaxAuthenticationFilter(String defaultFilterProcessesUrl) {
+		super(defaultFilterProcessesUrl);
+	}
+
+	@Override
+	public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws
+		AuthenticationException, IOException, ServletException {
+		//boolean isAjax = "XMLHttpRequest".equals(request.getHeader("X-Requested-With"));
+		//if (!isAjax) {
+		//    throw new IllegalStateException("Authentication is not supported");
+		//}
+		LoginRequestDto loginRequestDto = objectMapper.readValue(request.getReader(), LoginRequestDto.class);
+		if (!StringUtils.hasText(loginRequestDto.email()) || !StringUtils.hasText(loginRequestDto.password())) {
+			throw new UsernameNotFoundException("Username Or Password is Empty");
+		}
+		AjaxAuthenticationToken authRequest = AjaxAuthenticationToken
+			.unauthenticated(loginRequestDto.email(), loginRequestDto.password());
+		setDetails(request, authRequest);
+		return getAuthenticationManager().authenticate(authRequest);
+	}
+
+	protected void setDetails(HttpServletRequest request, AjaxAuthenticationToken authRequest) {
+		authRequest.setDetails(this.authenticationDetailsSource.buildDetails(request));
+	}
+}

--- a/src/main/java/com/fastcampus/mini9/config/security/filter/AjaxAuthenticationFilter.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/filter/AjaxAuthenticationFilter.java
@@ -32,11 +32,11 @@ public class AjaxAuthenticationFilter extends AbstractAuthenticationProcessingFi
 		//    throw new IllegalStateException("Authentication is not supported");
 		//}
 		LoginRequestDto loginRequestDto = objectMapper.readValue(request.getReader(), LoginRequestDto.class);
-		if (!StringUtils.hasText(loginRequestDto.email()) || !StringUtils.hasText(loginRequestDto.password())) {
+		if (!StringUtils.hasText(loginRequestDto.email()) || !StringUtils.hasText(loginRequestDto.pwd())) {
 			throw new UsernameNotFoundException("Username Or Password is Empty");
 		}
 		AjaxAuthenticationToken authRequest = AjaxAuthenticationToken
-			.unauthenticated(loginRequestDto.email(), loginRequestDto.password());
+			.unauthenticated(loginRequestDto.email(), loginRequestDto.pwd());
 		setDetails(request, authRequest);
 		return getAuthenticationManager().authenticate(authRequest);
 	}

--- a/src/main/java/com/fastcampus/mini9/config/security/filter/AjaxAuthenticationFilterConfigurer.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/filter/AjaxAuthenticationFilterConfigurer.java
@@ -1,5 +1,6 @@
 package com.fastcampus.mini9.config.security.filter;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.security.authentication.AuthenticationDetailsSource;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -11,71 +12,69 @@ import org.springframework.security.web.authentication.session.SessionAuthentica
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 
-import jakarta.servlet.http.HttpServletRequest;
-
 public class AjaxAuthenticationFilterConfigurer extends
-	AbstractAuthenticationFilterConfigurer<HttpSecurity, AjaxAuthenticationFilterConfigurer, AjaxAuthenticationFilter> {
+    AbstractAuthenticationFilterConfigurer<HttpSecurity, AjaxAuthenticationFilterConfigurer, AjaxAuthenticationFilter> {
 
-	private AuthenticationManager authenticationManager;
-	private AuthenticationSuccessHandler successHandler;
-	private AuthenticationFailureHandler failureHandler;
-	private AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource;
+    private AuthenticationManager authenticationManager;
+    private AuthenticationSuccessHandler successHandler;
+    private AuthenticationFailureHandler failureHandler;
+    private AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource;
 
-	public AjaxAuthenticationFilterConfigurer(AjaxAuthenticationFilter authenticationFilter,
-		String defaultLoginProcessingUrl) {
-		super(authenticationFilter, defaultLoginProcessingUrl);
-	}
+    public AjaxAuthenticationFilterConfigurer(AjaxAuthenticationFilter authenticationFilter,
+                                              String defaultLoginProcessingUrl) {
+        super(authenticationFilter, defaultLoginProcessingUrl);
+    }
 
-	@Override
-	public void init(HttpSecurity http) throws Exception {
-		super.init(http);
-	}
+    @Override
+    public void init(HttpSecurity http) throws Exception {
+        super.init(http);
+    }
 
-	@Override
-	public void configure(HttpSecurity http) throws Exception {
-		AjaxAuthenticationFilter filter = getAuthenticationFilter();
-		if (authenticationManager == null) {
-			authenticationManager = http.getSharedObject(AuthenticationManager.class);
-		}
-		filter.setAuthenticationManager(authenticationManager);
-		filter.setAuthenticationSuccessHandler(successHandler);
-		filter.setAuthenticationFailureHandler(failureHandler);
-		filter.setAuthenticationDetailsSource(authenticationDetailsSource);
-		SessionAuthenticationStrategy sessionAuthenticationStrategy = http.getSharedObject(
-			SessionAuthenticationStrategy.class);
-		if (sessionAuthenticationStrategy != null) {
-			filter.setSessionAuthenticationStrategy(sessionAuthenticationStrategy);
-		}
-		http.setSharedObject(AjaxAuthenticationFilter.class, getAuthenticationFilter());
-		http.addFilterBefore(getAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
-	}
+    @Override
+    public void configure(HttpSecurity http) throws Exception {
+        AjaxAuthenticationFilter filter = getAuthenticationFilter();
+        if (authenticationManager == null) {
+            authenticationManager = http.getSharedObject(AuthenticationManager.class);
+        }
+        filter.setAuthenticationManager(authenticationManager);
+        filter.setAuthenticationSuccessHandler(successHandler);
+        filter.setAuthenticationFailureHandler(failureHandler);
+        filter.setAuthenticationDetailsSource(authenticationDetailsSource);
+        SessionAuthenticationStrategy sessionAuthenticationStrategy = http.getSharedObject(
+            SessionAuthenticationStrategy.class);
+        if (sessionAuthenticationStrategy != null) {
+            filter.setSessionAuthenticationStrategy(sessionAuthenticationStrategy);
+        }
+        http.setSharedObject(AjaxAuthenticationFilter.class, getAuthenticationFilter());
+        http.addFilterBefore(getAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+    }
 
-	public AjaxAuthenticationFilterConfigurer successHandlerAjax(
-		AuthenticationSuccessHandler successHandler) {
-		this.successHandler = successHandler;
-		return this;
-	}
+    public AjaxAuthenticationFilterConfigurer successHandlerAjax(
+        AuthenticationSuccessHandler successHandler) {
+        this.successHandler = successHandler;
+        return this;
+    }
 
-	public AjaxAuthenticationFilterConfigurer failureHandlerAjax(
-		AuthenticationFailureHandler authenticationFailureHandler) {
-		this.failureHandler = authenticationFailureHandler;
-		return this;
-	}
+    public AjaxAuthenticationFilterConfigurer failureHandlerAjax(
+        AuthenticationFailureHandler authenticationFailureHandler) {
+        this.failureHandler = authenticationFailureHandler;
+        return this;
+    }
 
-	public AjaxAuthenticationFilterConfigurer setAuthenticationManager(
-		AuthenticationManager authenticationManager) {
-		this.authenticationManager = authenticationManager;
-		return this;
-	}
+    public AjaxAuthenticationFilterConfigurer setAuthenticationManager(
+        AuthenticationManager authenticationManager) {
+        this.authenticationManager = authenticationManager;
+        return this;
+    }
 
-	public AjaxAuthenticationFilterConfigurer setAuthenticationDetailsSource(
-		AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource) {
-		this.authenticationDetailsSource = authenticationDetailsSource;
-		return this;
-	}
+    public AjaxAuthenticationFilterConfigurer setAuthenticationDetailsSource(
+        AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource) {
+        this.authenticationDetailsSource = authenticationDetailsSource;
+        return this;
+    }
 
-	@Override
-	protected RequestMatcher createLoginProcessingUrlMatcher(String loginProcessingUrl) {
-		return new AntPathRequestMatcher(loginProcessingUrl, "POST");
-	}
+    @Override
+    protected RequestMatcher createLoginProcessingUrlMatcher(String loginProcessingUrl) {
+        return new AntPathRequestMatcher(loginProcessingUrl, "POST");
+    }
 }

--- a/src/main/java/com/fastcampus/mini9/config/security/filter/AjaxAuthenticationFilterConfigurer.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/filter/AjaxAuthenticationFilterConfigurer.java
@@ -1,0 +1,81 @@
+package com.fastcampus.mini9.config.security.filter;
+
+import org.springframework.security.authentication.AuthenticationDetailsSource;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractAuthenticationFilterConfigurer;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public class AjaxAuthenticationFilterConfigurer extends
+	AbstractAuthenticationFilterConfigurer<HttpSecurity, AjaxAuthenticationFilterConfigurer, AjaxAuthenticationFilter> {
+
+	private AuthenticationManager authenticationManager;
+	private AuthenticationSuccessHandler successHandler;
+	private AuthenticationFailureHandler failureHandler;
+	private AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource;
+
+	public AjaxAuthenticationFilterConfigurer(AjaxAuthenticationFilter authenticationFilter,
+		String defaultLoginProcessingUrl) {
+		super(authenticationFilter, defaultLoginProcessingUrl);
+	}
+
+	@Override
+	public void init(HttpSecurity http) throws Exception {
+		super.init(http);
+	}
+
+	@Override
+	public void configure(HttpSecurity http) throws Exception {
+		AjaxAuthenticationFilter filter = getAuthenticationFilter();
+		if (authenticationManager == null) {
+			authenticationManager = http.getSharedObject(AuthenticationManager.class);
+		}
+		filter.setAuthenticationManager(authenticationManager);
+		filter.setAuthenticationSuccessHandler(successHandler);
+		filter.setAuthenticationFailureHandler(failureHandler);
+		filter.setAuthenticationDetailsSource(authenticationDetailsSource);
+		SessionAuthenticationStrategy sessionAuthenticationStrategy = http.getSharedObject(
+			SessionAuthenticationStrategy.class);
+		if (sessionAuthenticationStrategy != null) {
+			filter.setSessionAuthenticationStrategy(sessionAuthenticationStrategy);
+		}
+		http.setSharedObject(AjaxAuthenticationFilter.class, getAuthenticationFilter());
+		http.addFilterBefore(getAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+	}
+
+	public AjaxAuthenticationFilterConfigurer successHandlerAjax(
+		AuthenticationSuccessHandler successHandler) {
+		this.successHandler = successHandler;
+		return this;
+	}
+
+	public AjaxAuthenticationFilterConfigurer failureHandlerAjax(
+		AuthenticationFailureHandler authenticationFailureHandler) {
+		this.failureHandler = authenticationFailureHandler;
+		return this;
+	}
+
+	public AjaxAuthenticationFilterConfigurer setAuthenticationManager(
+		AuthenticationManager authenticationManager) {
+		this.authenticationManager = authenticationManager;
+		return this;
+	}
+
+	public AjaxAuthenticationFilterConfigurer setAuthenticationDetailsSource(
+		AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource) {
+		this.authenticationDetailsSource = authenticationDetailsSource;
+		return this;
+	}
+
+	@Override
+	protected RequestMatcher createLoginProcessingUrlMatcher(String loginProcessingUrl) {
+		return new AntPathRequestMatcher(loginProcessingUrl, "POST");
+	}
+}

--- a/src/main/java/com/fastcampus/mini9/config/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/filter/JwtAuthenticationFilter.java
@@ -99,7 +99,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		HttpServletResponse response, Authentication authResult) {
 		if (authResult instanceof JwtAuthenticationToken jwtAuthToken
 			&& jwtAuthToken.isRegenerated()) {
-			CookieUtil.addCookie(response, "access-token", jwtAuthToken.getNewAccessToken(),
+			CookieUtil.addCookieWithoutHttp(response, "access-token", jwtAuthToken.getNewAccessToken(),
 				60 * 24);
 			CookieUtil.addCookie(response, "refresh-token", jwtAuthToken.getNewRefreshToken(),
 				60 * 60 * 24);

--- a/src/main/java/com/fastcampus/mini9/config/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/filter/JwtAuthenticationFilter.java
@@ -1,8 +1,14 @@
 package com.fastcampus.mini9.config.security.filter;
 
+import com.fastcampus.mini9.common.util.cookie.CookieUtil;
+import com.fastcampus.mini9.config.security.token.JwtAuthenticationToken;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Optional;
-
 import org.springframework.core.log.LogMessage;
 import org.springframework.security.authentication.AuthenticationDetailsSource;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -14,96 +20,89 @@ import org.springframework.security.core.context.SecurityContextHolderStrategy;
 import org.springframework.util.Assert;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import com.fastcampus.mini9.common.util.cookie.CookieUtil;
-import com.fastcampus.mini9.config.security.token.JwtAuthenticationToken;
-
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-	private SecurityContextHolderStrategy securityContextHolderStrategy = SecurityContextHolder
-		.getContextHolderStrategy();
+    private final AuthenticationManager authenticationManager;
+    private final AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource;
+    private SecurityContextHolderStrategy securityContextHolderStrategy = SecurityContextHolder
+        .getContextHolderStrategy();
 
-	private final AuthenticationManager authenticationManager;
-	private final AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource;
+    public JwtAuthenticationFilter(AuthenticationManager authenticationManager,
+                                   AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource) {
+        this.authenticationManager = authenticationManager;
+        this.authenticationDetailsSource = authenticationDetailsSource;
+    }
 
-	public JwtAuthenticationFilter(AuthenticationManager authenticationManager,
-		AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource) {
-		this.authenticationManager = authenticationManager;
-		this.authenticationDetailsSource = authenticationDetailsSource;
-	}
+    @Override
+    public void afterPropertiesSet() {
+        Assert.notNull(this.authenticationManager, "authenticationManager must be specified");
+        Assert.notNull(this.authenticationDetailsSource,
+            "authenticationDetailsSource must be specified");
+    }
 
-	@Override
-	public void afterPropertiesSet() {
-		Assert.notNull(this.authenticationManager, "authenticationManager must be specified");
-		Assert.notNull(this.authenticationDetailsSource,
-			"authenticationDetailsSource must be specified");
-	}
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain chain) throws
+        ServletException, IOException {
+        if (this.securityContextHolderStrategy.getContext().getAuthentication() != null) {
+            this.logger.debug(LogMessage
+                .of(() ->
+                    "SecurityContextHolder not populated with jwt token, as it already contained: '"
+                        + this.securityContextHolderStrategy.getContext().getAuthentication()
+                        + "'"));
+            chain.doFilter(request, response);
+            return;
+        }
+        Optional<Cookie> accessToken = CookieUtil.getCookie(request, "access-token");
+        Optional<Cookie> refreshToken = CookieUtil.getCookie(request, "refresh-token");
+        if (accessToken.isPresent()) {
+            JwtAuthenticationToken jwtAuth = JwtAuthenticationToken.unauthenticated(
+                accessToken.get().getValue(),
+                refreshToken.isPresent() ? refreshToken.get().getValue() : "empty");
+            setDetails(request, jwtAuth);
+            // Attempt authentication via AuthenticationManager
+            try {
+                Authentication authResult = this.authenticationManager.authenticate(jwtAuth);
+                SecurityContext context = this.securityContextHolderStrategy.createEmptyContext();
+                context.setAuthentication(authResult);
+                this.securityContextHolderStrategy.setContext(context);
+                onSuccessfulAuthentication(request, response, authResult);
+                this.logger.debug(
+                    LogMessage.of(() -> "SecurityContextHolder populated with jwt token: '"
+                        + this.securityContextHolderStrategy.getContext().getAuthentication()
+                        + "'"));
+            } catch (AuthenticationException ex) {
+                this.logger.debug(LogMessage
+                        .format(
+                            "SecurityContextHolder not populated with jwt token, "
+                                + "as AuthenticationManager rejected Authentication returned "
+                                + "by JwtProvider: '%s'; "
+                                + "invalidating jwt token", jwtAuth),
+                    ex);
+                onUnsuccessfulAuthentication(request, response, ex);
+            }
+        }
+        chain.doFilter(request, response);
+    }
 
-	@Override
-	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws
-		ServletException, IOException {
-		if (this.securityContextHolderStrategy.getContext().getAuthentication() != null) {
-			this.logger.debug(LogMessage
-				.of(() ->
-					"SecurityContextHolder not populated with jwt token, as it already contained: '"
-						+ this.securityContextHolderStrategy.getContext().getAuthentication()
-						+ "'"));
-			chain.doFilter(request, response);
-			return;
-		}
-		Optional<Cookie> accessToken = CookieUtil.getCookie(request, "access-token");
-		Optional<Cookie> refreshToken = CookieUtil.getCookie(request, "refresh-token");
-		if (accessToken.isPresent()) {
-			JwtAuthenticationToken jwtAuth = JwtAuthenticationToken.unauthenticated(
-				accessToken.get().getValue(),
-				refreshToken.isPresent() ? refreshToken.get().getValue() : "empty");
-			setDetails(request, jwtAuth);
-			// Attempt authentication via AuthenticationManager
-			try {
-				Authentication authResult = this.authenticationManager.authenticate(jwtAuth);
-				SecurityContext context = this.securityContextHolderStrategy.createEmptyContext();
-				context.setAuthentication(authResult);
-				this.securityContextHolderStrategy.setContext(context);
-				onSuccessfulAuthentication(request, response, authResult);
-				this.logger.debug(
-					LogMessage.of(() -> "SecurityContextHolder populated with jwt token: '"
-						+ this.securityContextHolderStrategy.getContext().getAuthentication()
-						+ "'"));
-			} catch (AuthenticationException ex) {
-				this.logger.debug(LogMessage
-						.format(
-							"SecurityContextHolder not populated with jwt token, "
-								+ "as AuthenticationManager rejected Authentication returned "
-								+ "by JwtProvider: '%s'; "
-								+ "invalidating jwt token", jwtAuth),
-					ex);
-				onUnsuccessfulAuthentication(request, response, ex);
-			}
-		}
-		chain.doFilter(request, response);
-	}
+    protected void setDetails(HttpServletRequest request, JwtAuthenticationToken authRequest) {
+        authRequest.setDetails(this.authenticationDetailsSource.buildDetails(request));
+    }
 
-	protected void setDetails(HttpServletRequest request, JwtAuthenticationToken authRequest) {
-		authRequest.setDetails(this.authenticationDetailsSource.buildDetails(request));
-	}
+    protected void onSuccessfulAuthentication(HttpServletRequest request,
+                                              HttpServletResponse response,
+                                              Authentication authResult) {
+        if (authResult instanceof JwtAuthenticationToken jwtAuthToken
+            && jwtAuthToken.isRegenerated()) {
+            CookieUtil.addCookie(response, "access-token", jwtAuthToken.getNewAccessToken(),
+                60 * 24);
+            CookieUtil.addCookie(response, "refresh-token", jwtAuthToken.getNewRefreshToken(),
+                60 * 60 * 24);
+        }
+    }
 
-	protected void onSuccessfulAuthentication(HttpServletRequest request,
-		HttpServletResponse response, Authentication authResult) {
-		if (authResult instanceof JwtAuthenticationToken jwtAuthToken
-			&& jwtAuthToken.isRegenerated()) {
-			CookieUtil.addCookie(response, "access-token", jwtAuthToken.getNewAccessToken(),
-				60 * 24);
-			CookieUtil.addCookie(response, "refresh-token", jwtAuthToken.getNewRefreshToken(),
-				60 * 60 * 24);
-		}
-	}
-
-	protected void onUnsuccessfulAuthentication(HttpServletRequest request,
-		HttpServletResponse response, AuthenticationException failed) {
-	}
+    protected void onUnsuccessfulAuthentication(HttpServletRequest request,
+                                                HttpServletResponse response,
+                                                AuthenticationException failed) {
+    }
 }

--- a/src/main/java/com/fastcampus/mini9/config/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/filter/JwtAuthenticationFilter.java
@@ -56,11 +56,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			chain.doFilter(request, response);
 			return;
 		}
-		Optional<Cookie> accessToken = CookieUtil.getCookie(request, "access-token");
-		Optional<Cookie> refreshToken = CookieUtil.getCookie(request, "refresh-token");
-		if (accessToken.isPresent()) {
+        String authHeader = request.getHeader("Authorization");
+        Optional<Cookie> refreshToken = CookieUtil.getCookie(request, "refresh-token");
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String accessToken = authHeader.substring(7);
 			JwtAuthenticationToken jwtAuth = JwtAuthenticationToken.unauthenticated(
-				accessToken.get().getValue(),
+				accessToken,
 				refreshToken.isPresent() ? refreshToken.get().getValue() : "empty");
 			setDetails(request, jwtAuth);
 			// Attempt authentication via AuthenticationManager

--- a/src/main/java/com/fastcampus/mini9/config/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,109 @@
+package com.fastcampus.mini9.config.security.filter;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import org.springframework.core.log.LogMessage;
+import org.springframework.security.authentication.AuthenticationDetailsSource;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextHolderStrategy;
+import org.springframework.util.Assert;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fastcampus.mini9.common.util.cookie.CookieUtil;
+import com.fastcampus.mini9.config.security.token.JwtAuthenticationToken;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	private SecurityContextHolderStrategy securityContextHolderStrategy = SecurityContextHolder
+		.getContextHolderStrategy();
+
+	private final AuthenticationManager authenticationManager;
+	private final AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource;
+
+	public JwtAuthenticationFilter(AuthenticationManager authenticationManager,
+		AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource) {
+		this.authenticationManager = authenticationManager;
+		this.authenticationDetailsSource = authenticationDetailsSource;
+	}
+
+	@Override
+	public void afterPropertiesSet() {
+		Assert.notNull(this.authenticationManager, "authenticationManager must be specified");
+		Assert.notNull(this.authenticationDetailsSource,
+			"authenticationDetailsSource must be specified");
+	}
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws
+		ServletException, IOException {
+		if (this.securityContextHolderStrategy.getContext().getAuthentication() != null) {
+			this.logger.debug(LogMessage
+				.of(() ->
+					"SecurityContextHolder not populated with jwt token, as it already contained: '"
+						+ this.securityContextHolderStrategy.getContext().getAuthentication()
+						+ "'"));
+			chain.doFilter(request, response);
+			return;
+		}
+		Optional<Cookie> accessToken = CookieUtil.getCookie(request, "access-token");
+		Optional<Cookie> refreshToken = CookieUtil.getCookie(request, "refresh-token");
+		if (accessToken.isPresent()) {
+			JwtAuthenticationToken jwtAuth = JwtAuthenticationToken.unauthenticated(
+				accessToken.get().getValue(),
+				refreshToken.isPresent() ? refreshToken.get().getValue() : "empty");
+			setDetails(request, jwtAuth);
+			// Attempt authentication via AuthenticationManager
+			try {
+				Authentication authResult = this.authenticationManager.authenticate(jwtAuth);
+				SecurityContext context = this.securityContextHolderStrategy.createEmptyContext();
+				context.setAuthentication(authResult);
+				this.securityContextHolderStrategy.setContext(context);
+				onSuccessfulAuthentication(request, response, authResult);
+				this.logger.debug(
+					LogMessage.of(() -> "SecurityContextHolder populated with jwt token: '"
+						+ this.securityContextHolderStrategy.getContext().getAuthentication()
+						+ "'"));
+			} catch (AuthenticationException ex) {
+				this.logger.debug(LogMessage
+						.format(
+							"SecurityContextHolder not populated with jwt token, "
+								+ "as AuthenticationManager rejected Authentication returned "
+								+ "by JwtProvider: '%s'; "
+								+ "invalidating jwt token", jwtAuth),
+					ex);
+				onUnsuccessfulAuthentication(request, response, ex);
+			}
+		}
+		chain.doFilter(request, response);
+	}
+
+	protected void setDetails(HttpServletRequest request, JwtAuthenticationToken authRequest) {
+		authRequest.setDetails(this.authenticationDetailsSource.buildDetails(request));
+	}
+
+	protected void onSuccessfulAuthentication(HttpServletRequest request,
+		HttpServletResponse response, Authentication authResult) {
+		if (authResult instanceof JwtAuthenticationToken jwtAuthToken
+			&& jwtAuthToken.isRegenerated()) {
+			CookieUtil.addCookie(response, "access-token", jwtAuthToken.getNewAccessToken(),
+				60 * 24);
+			CookieUtil.addCookie(response, "refresh-token", jwtAuthToken.getNewRefreshToken(),
+				60 * 60 * 24);
+		}
+	}
+
+	protected void onUnsuccessfulAuthentication(HttpServletRequest request,
+		HttpServletResponse response, AuthenticationException failed) {
+	}
+}

--- a/src/main/java/com/fastcampus/mini9/config/security/handler/AjaxAuthenticationFailureHandler.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/handler/AjaxAuthenticationFailureHandler.java
@@ -1,7 +1,11 @@
 package com.fastcampus.mini9.config.security.handler;
 
+import com.fastcampus.mini9.common.response.ErrorResponseBody;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -10,20 +14,14 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 
-import com.fastcampus.mini9.common.response.ErrorResponseBody;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-
 public class AjaxAuthenticationFailureHandler implements AuthenticationFailureHandler {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
-        AuthenticationException exception) throws IOException, ServletException {
+                                        AuthenticationException exception)
+        throws IOException, ServletException {
         response.setStatus(HttpStatus.OK.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");

--- a/src/main/java/com/fastcampus/mini9/config/security/handler/AjaxAuthenticationFailureHandler.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/handler/AjaxAuthenticationFailureHandler.java
@@ -32,7 +32,6 @@ public class AjaxAuthenticationFailureHandler implements AuthenticationFailureHa
         } else if (exception instanceof InsufficientAuthenticationException) {
             errorMessage = "Invalid Secret Key";
         } else if (exception instanceof UsernameNotFoundException) {
-            response.setStatus(HttpStatus.BAD_REQUEST.value());
             errorMessage = exception.getMessage();
         }
 

--- a/src/main/java/com/fastcampus/mini9/config/security/handler/AjaxAuthenticationFailureHandler.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/handler/AjaxAuthenticationFailureHandler.java
@@ -1,0 +1,43 @@
+package com.fastcampus.mini9.config.security.handler;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+
+import com.fastcampus.mini9.common.response.ErrorResponseBody;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class AjaxAuthenticationFailureHandler implements AuthenticationFailureHandler {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException exception) throws IOException, ServletException {
+        response.setStatus(HttpStatus.OK.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        String errorMessage = "Authentication Failed";
+        if (exception instanceof BadCredentialsException) {
+            errorMessage = "Invalid Username Or Password";
+        } else if (exception instanceof InsufficientAuthenticationException) {
+            errorMessage = "Invalid Secret Key";
+        } else if (exception instanceof UsernameNotFoundException) {
+            response.setStatus(HttpStatus.BAD_REQUEST.value());
+            errorMessage = exception.getMessage();
+        }
+
+        objectMapper.writeValue(response.getWriter(), ErrorResponseBody.unsuccessful(errorMessage));
+    }
+}

--- a/src/main/java/com/fastcampus/mini9/config/security/handler/AjaxAuthenticationSuccessHandler.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/handler/AjaxAuthenticationSuccessHandler.java
@@ -1,12 +1,5 @@
 package com.fastcampus.mini9.config.security.handler;
 
-import java.io.IOException;
-
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
-
 import com.fastcampus.mini9.common.response.BaseResponseBody;
 import com.fastcampus.mini9.common.util.cookie.CookieUtil;
 import com.fastcampus.mini9.config.security.provider.JwtProvider;
@@ -14,10 +7,14 @@ import com.fastcampus.mini9.config.security.service.RefreshTokenService;
 import com.fastcampus.mini9.config.security.token.AuthenticationDetails;
 import com.fastcampus.mini9.config.security.token.UserPrincipal;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 
 public class AjaxAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
 
@@ -26,14 +23,15 @@ public class AjaxAuthenticationSuccessHandler implements AuthenticationSuccessHa
     private final RefreshTokenService refreshTokenService;
 
     public AjaxAuthenticationSuccessHandler(JwtProvider jwtProvider,
-        RefreshTokenService refreshTokenService) {
+                                            RefreshTokenService refreshTokenService) {
         this.jwtProvider = jwtProvider;
         this.refreshTokenService = refreshTokenService;
     }
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
-        Authentication authentication) throws IOException, ServletException {
+                                        Authentication authentication)
+        throws IOException, ServletException {
         // access-token
         String accessToken = jwtProvider.generateAccessToken(authentication);
 

--- a/src/main/java/com/fastcampus/mini9/config/security/handler/AjaxAuthenticationSuccessHandler.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/handler/AjaxAuthenticationSuccessHandler.java
@@ -1,7 +1,10 @@
 package com.fastcampus.mini9.config.security.handler;
 
+import com.fastcampus.mini9.common.response.DataResponseBody;
 import java.io.IOException;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
@@ -51,6 +54,8 @@ public class AjaxAuthenticationSuccessHandler implements AuthenticationSuccessHa
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
 
-        objectMapper.writeValue(response.getWriter(), BaseResponseBody.success("login success"));
+        Map<String, String> tokenData = new HashMap<>();
+        tokenData.put("access_token", accessToken);
+        objectMapper.writeValue(response.getWriter(),  DataResponseBody.success(tokenData));
     }
 }

--- a/src/main/java/com/fastcampus/mini9/config/security/handler/AjaxAuthenticationSuccessHandler.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/handler/AjaxAuthenticationSuccessHandler.java
@@ -40,7 +40,7 @@ public class AjaxAuthenticationSuccessHandler implements AuthenticationSuccessHa
         // access-token
         String accessToken = jwtProvider.generateAccessToken(authentication);
 
-        CookieUtil.addCookie(response, "access-token", accessToken, 60 * 30);
+        CookieUtil.addCookieWithoutSecure(response, "access-token", accessToken, 60 * 30);
 
         // refresh-token
         UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();

--- a/src/main/java/com/fastcampus/mini9/config/security/handler/AjaxAuthenticationSuccessHandler.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/handler/AjaxAuthenticationSuccessHandler.java
@@ -37,7 +37,7 @@ public class AjaxAuthenticationSuccessHandler implements AuthenticationSuccessHa
         // access-token
         String accessToken = jwtProvider.generateAccessToken(authentication);
 
-        CookieUtil.addCookieWithoutSecure(response, "access-token", accessToken, 60 * 30);
+        CookieUtil.addCookieWithoutHttp(response, "access-token", accessToken, 60 * 30);
 
         // refresh-token
         UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();

--- a/src/main/java/com/fastcampus/mini9/config/security/handler/AjaxAuthenticationSuccessHandler.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/handler/AjaxAuthenticationSuccessHandler.java
@@ -1,0 +1,56 @@
+package com.fastcampus.mini9.config.security.handler;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+import com.fastcampus.mini9.common.response.BaseResponseBody;
+import com.fastcampus.mini9.common.util.cookie.CookieUtil;
+import com.fastcampus.mini9.config.security.provider.JwtProvider;
+import com.fastcampus.mini9.config.security.service.RefreshTokenService;
+import com.fastcampus.mini9.config.security.token.AuthenticationDetails;
+import com.fastcampus.mini9.config.security.token.UserPrincipal;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class AjaxAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenService refreshTokenService;
+
+    public AjaxAuthenticationSuccessHandler(JwtProvider jwtProvider,
+        RefreshTokenService refreshTokenService) {
+        this.jwtProvider = jwtProvider;
+        this.refreshTokenService = refreshTokenService;
+    }
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+        Authentication authentication) throws IOException, ServletException {
+        // access-token
+        String accessToken = jwtProvider.generateAccessToken(authentication);
+
+        CookieUtil.addCookie(response, "access-token", accessToken, 60 * 30);
+
+        // refresh-token
+        UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
+        AuthenticationDetails details = (AuthenticationDetails) authentication.getDetails();
+        String refreshTokenValue = refreshTokenService.updateRefreshToken(principal, details);
+
+        CookieUtil.addCookie(response, "refresh-token", refreshTokenValue, 60 * 60 * 24);
+
+        // response
+        response.setStatus(HttpStatus.OK.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        objectMapper.writeValue(response.getWriter(), BaseResponseBody.success("login success"));
+    }
+}

--- a/src/main/java/com/fastcampus/mini9/config/security/handler/JwtLogoutHandler.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/handler/JwtLogoutHandler.java
@@ -1,0 +1,17 @@
+package com.fastcampus.mini9.config.security.handler;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+
+import com.fastcampus.mini9.common.util.cookie.CookieUtil;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class JwtLogoutHandler implements LogoutHandler {
+	@Override
+	public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+		CookieUtil.deleteCookie(request,response,"access-token");
+		CookieUtil.deleteCookie(request,response,"refresh-token");
+	}
+}

--- a/src/main/java/com/fastcampus/mini9/config/security/handler/JwtLogoutSuccessHandler.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/handler/JwtLogoutSuccessHandler.java
@@ -1,0 +1,29 @@
+package com.fastcampus.mini9.config.security.handler;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+
+import com.fastcampus.mini9.common.response.BaseResponseBody;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class JwtLogoutSuccessHandler implements LogoutSuccessHandler {
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Override
+	public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response,
+		Authentication authentication) throws IOException, ServletException {
+		response.setStatus(HttpStatus.OK.value());
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding("UTF-8");
+
+		objectMapper.writeValue(response.getWriter(), BaseResponseBody.success("logout success"));
+	}
+}

--- a/src/main/java/com/fastcampus/mini9/config/security/provider/AjaxAuthenticationProvider.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/provider/AjaxAuthenticationProvider.java
@@ -1,0 +1,47 @@
+package com.fastcampus.mini9.config.security.provider;
+
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.fastcampus.mini9.config.security.service.AjaxUserDetailService;
+import com.fastcampus.mini9.config.security.service.UserDetailsWithId;
+import com.fastcampus.mini9.config.security.token.AjaxAuthenticationToken;
+import com.fastcampus.mini9.config.security.token.UserPrincipal;
+
+public class AjaxAuthenticationProvider implements AuthenticationProvider {
+
+    private final AjaxUserDetailService userDetailService;
+    private final PasswordEncoder passwordEncoder;
+
+    public AjaxAuthenticationProvider(AjaxUserDetailService userDetailService,
+        PasswordEncoder passwordEncoder) {
+        this.userDetailService = userDetailService;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication)
+        throws AuthenticationException {
+        String username = authentication.getName();
+        String password = (String) authentication.getCredentials();
+        UserDetailsWithId userDetails = (UserDetailsWithId) userDetailService.loadUserByUsername(
+            username);
+        if (!passwordEncoder.matches(password, userDetails.getPassword())) {
+            throw new BadCredentialsException("BadCredentialsException");
+        }
+        UserPrincipal userPrincipal = new UserPrincipal(userDetails.getUserId(),
+            userDetails.getUsername());
+        AjaxAuthenticationToken result = AjaxAuthenticationToken.authenticated(userPrincipal, null,
+            userDetails.getAuthorities());
+        result.setDetails(authentication.getDetails());
+        return result;
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return AjaxAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}

--- a/src/main/java/com/fastcampus/mini9/config/security/provider/AjaxAuthenticationProvider.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/provider/AjaxAuthenticationProvider.java
@@ -1,15 +1,14 @@
 package com.fastcampus.mini9.config.security.provider;
 
+import com.fastcampus.mini9.config.security.service.AjaxUserDetailService;
+import com.fastcampus.mini9.config.security.service.UserDetailsWithId;
+import com.fastcampus.mini9.config.security.token.AjaxAuthenticationToken;
+import com.fastcampus.mini9.config.security.token.UserPrincipal;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
-
-import com.fastcampus.mini9.config.security.service.AjaxUserDetailService;
-import com.fastcampus.mini9.config.security.service.UserDetailsWithId;
-import com.fastcampus.mini9.config.security.token.AjaxAuthenticationToken;
-import com.fastcampus.mini9.config.security.token.UserPrincipal;
 
 public class AjaxAuthenticationProvider implements AuthenticationProvider {
 
@@ -17,7 +16,7 @@ public class AjaxAuthenticationProvider implements AuthenticationProvider {
     private final PasswordEncoder passwordEncoder;
 
     public AjaxAuthenticationProvider(AjaxUserDetailService userDetailService,
-        PasswordEncoder passwordEncoder) {
+                                      PasswordEncoder passwordEncoder) {
         this.userDetailService = userDetailService;
         this.passwordEncoder = passwordEncoder;
     }

--- a/src/main/java/com/fastcampus/mini9/config/security/provider/JwtProvider.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/provider/JwtProvider.java
@@ -1,0 +1,118 @@
+package com.fastcampus.mini9.config.security.provider;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.fastcampus.mini9.config.security.exception.InvalidJwtException;
+import com.fastcampus.mini9.config.security.service.RefreshTokenService;
+import com.fastcampus.mini9.config.security.token.AuthenticationDetails;
+import com.fastcampus.mini9.config.security.token.JwtAuthenticationToken;
+import com.fastcampus.mini9.config.security.token.UserPrincipal;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Component
+public class JwtProvider implements AuthenticationProvider {
+
+    private final String issuer;
+    private long accessTokenValidityInMs;
+    private final Algorithm algorithm;
+    private final JWTVerifier verifier;
+
+    private final RefreshTokenService refreshTokenService;
+    private final long refreshTokenValidityInMs;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final Logger logger = LoggerFactory.getLogger(JwtProvider.class);
+
+    public JwtProvider(@Value("${jwt.secret-key}") String secretKey,
+        @Value("${jwt.issuer}") String issuer,
+        @Value("${jwt.access-token-expire-time}") long accessTokenValidityInMs,
+        RefreshTokenService refreshTokenService,
+        @Value("${jwt.refresh-token-expire-time}") long refreshTokenValidityInMs) {
+        this.algorithm = Algorithm.HMAC256(secretKey);
+        this.issuer = issuer;
+        this.accessTokenValidityInMs = accessTokenValidityInMs;
+        this.refreshTokenService = refreshTokenService;
+        this.refreshTokenValidityInMs = refreshTokenValidityInMs;
+        this.verifier = JWT.require(algorithm).withIssuer(issuer).build();
+    }
+
+    public String generateAccessToken(Authentication authToken) {
+        LocalDateTime now = LocalDateTime.now();
+        return JWT.create()
+            .withSubject(authToken.getName())
+            .withClaim("authn", objectMapper.convertValue(authToken.getPrincipal(),
+                new TypeReference<Map<String, Object>>() {
+                }))
+            .withArrayClaim("authgr",
+                authToken.getAuthorities().stream().map(GrantedAuthority::getAuthority)
+                    .toArray(String[]::new))
+            .withIssuer(issuer)
+            .withIssuedAt(now.atZone(ZoneId.systemDefault()).toInstant())
+            .withExpiresAt(
+                now.plus(accessTokenValidityInMs, ChronoUnit.MILLIS).atZone(ZoneId.systemDefault())
+                    .toInstant())
+            .sign(algorithm);
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication)
+        throws AuthenticationException {
+        String accessTokenValue = (String) authentication.getPrincipal();
+        String refreshTokenValue = (String) authentication.getCredentials();
+        JwtAuthenticationToken authResult = null;
+        try {
+            DecodedJWT decodedJwt = verifier.verify(accessTokenValue);
+            UserPrincipal userPrincipal = decodedJwt.getClaim("authn").as(UserPrincipal.class);
+            List<SimpleGrantedAuthority> authorities = decodedJwt.getClaim("authgr")
+                .asList(SimpleGrantedAuthority.class);
+            authResult = JwtAuthenticationToken.authenticated(userPrincipal, null, authorities);
+        } catch (TokenExpiredException ex) {
+            DecodedJWT decodedJwt = JWT.decode(accessTokenValue);
+            UserPrincipal userPrincipal = decodedJwt.getClaim("authn").as(UserPrincipal.class);
+            List<SimpleGrantedAuthority> authorities = decodedJwt.getClaim("authgr")
+                .asList(SimpleGrantedAuthority.class);
+            AuthenticationDetails details = (AuthenticationDetails) authentication.getDetails();
+            boolean isValidRefreshToken = refreshTokenService.isValidRefreshToken(refreshTokenValue,
+                userPrincipal, details);
+            if (isValidRefreshToken) {
+                authResult = JwtAuthenticationToken.authenticated(
+                    userPrincipal, null, authorities);
+                String newAccessToken = generateAccessToken(authResult);
+                String newRefreshToken = refreshTokenService.updateRefreshToken(userPrincipal,
+                    details);
+                authResult = JwtAuthenticationToken.authenticated(
+                    userPrincipal, null, authorities, newAccessToken, newRefreshToken);
+            }
+        } catch (JWTVerificationException ex) {
+            throw new InvalidJwtException(ex.getMessage(), ex);
+        }
+        authResult.setDetails(authentication.getDetails());
+        return authResult;
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return JwtAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}

--- a/src/main/java/com/fastcampus/mini9/config/security/provider/JwtProvider.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/provider/JwtProvider.java
@@ -1,21 +1,5 @@
 package com.fastcampus.mini9.config.security.provider;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.temporal.ChronoUnit;
-import java.util.List;
-import java.util.Map;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.authentication.AuthenticationProvider;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.stereotype.Component;
-
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
@@ -29,26 +13,38 @@ import com.fastcampus.mini9.config.security.token.JwtAuthenticationToken;
 import com.fastcampus.mini9.config.security.token.UserPrincipal;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
 
 @Component
 public class JwtProvider implements AuthenticationProvider {
 
     private final String issuer;
-    private long accessTokenValidityInMs;
     private final Algorithm algorithm;
     private final JWTVerifier verifier;
-
     private final RefreshTokenService refreshTokenService;
     private final long refreshTokenValidityInMs;
     private final ObjectMapper objectMapper = new ObjectMapper();
-
     private final Logger logger = LoggerFactory.getLogger(JwtProvider.class);
+    private long accessTokenValidityInMs;
 
     public JwtProvider(@Value("${jwt.secret-key}") String secretKey,
-        @Value("${jwt.issuer}") String issuer,
-        @Value("${jwt.access-token-expire-time}") long accessTokenValidityInMs,
-        RefreshTokenService refreshTokenService,
-        @Value("${jwt.refresh-token-expire-time}") long refreshTokenValidityInMs) {
+                       @Value("${jwt.issuer}") String issuer,
+                       @Value("${jwt.access-token-expire-time}") long accessTokenValidityInMs,
+                       RefreshTokenService refreshTokenService,
+                       @Value("${jwt.refresh-token-expire-time}") long refreshTokenValidityInMs) {
         this.algorithm = Algorithm.HMAC256(secretKey);
         this.issuer = issuer;
         this.accessTokenValidityInMs = accessTokenValidityInMs;

--- a/src/main/java/com/fastcampus/mini9/config/security/service/AjaxUserDetailService.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/service/AjaxUserDetailService.java
@@ -1,0 +1,31 @@
+package com.fastcampus.mini9.config.security.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import com.fastcampus.mini9.domain.member.entity.Member;
+import com.fastcampus.mini9.domain.member.repository.MemberRepository;
+
+public class AjaxUserDetailService implements UserDetailsService {
+
+	private final MemberRepository memberRepository;
+
+	public AjaxUserDetailService(MemberRepository memberRepository) {
+		this.memberRepository = memberRepository;
+	}
+
+	@Override
+	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+		Member member = memberRepository.findByEmail(username)
+			.orElseThrow(() -> new UsernameNotFoundException("no such member"));
+		List<GrantedAuthority> roles = new ArrayList<>();
+		roles.add(new SimpleGrantedAuthority("USER"));
+		return new UserDetailsWithId(member.getId(), member.getEmail(), member.getPwd(), roles);
+	}
+}

--- a/src/main/java/com/fastcampus/mini9/config/security/service/AjaxUserDetailService.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/service/AjaxUserDetailService.java
@@ -1,31 +1,29 @@
 package com.fastcampus.mini9.config.security.service;
 
+import com.fastcampus.mini9.domain.member.entity.Member;
+import com.fastcampus.mini9.domain.member.repository.MemberRepository;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
-import com.fastcampus.mini9.domain.member.entity.Member;
-import com.fastcampus.mini9.domain.member.repository.MemberRepository;
-
 public class AjaxUserDetailService implements UserDetailsService {
 
-	private final MemberRepository memberRepository;
+    private final MemberRepository memberRepository;
 
-	public AjaxUserDetailService(MemberRepository memberRepository) {
-		this.memberRepository = memberRepository;
-	}
+    public AjaxUserDetailService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
 
-	@Override
-	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-		Member member = memberRepository.findByEmail(username)
-			.orElseThrow(() -> new UsernameNotFoundException("no such member"));
-		List<GrantedAuthority> roles = new ArrayList<>();
-		roles.add(new SimpleGrantedAuthority("USER"));
-		return new UserDetailsWithId(member.getId(), member.getEmail(), member.getPwd(), roles);
-	}
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Member member = memberRepository.findByEmail(username)
+            .orElseThrow(() -> new UsernameNotFoundException("no such member"));
+        List<GrantedAuthority> roles = new ArrayList<>();
+        roles.add(new SimpleGrantedAuthority("USER"));
+        return new UserDetailsWithId(member.getId(), member.getEmail(), member.getPwd(), roles);
+    }
 }

--- a/src/main/java/com/fastcampus/mini9/config/security/service/RefreshTokenService.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/service/RefreshTokenService.java
@@ -1,0 +1,53 @@
+package com.fastcampus.mini9.config.security.service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fastcampus.mini9.config.security.exception.RefreshTokenException;
+import com.fastcampus.mini9.config.security.token.AuthenticationDetails;
+import com.fastcampus.mini9.config.security.token.UserPrincipal;
+import com.fastcampus.mini9.domain.member.entity.RefreshToken;
+import com.fastcampus.mini9.domain.member.repository.RefreshTokenRepository;
+
+@Service
+@Transactional(readOnly = true)
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public RefreshTokenService(RefreshTokenRepository refreshTokenRepository) {
+        this.refreshTokenRepository = refreshTokenRepository;
+    }
+
+    public boolean isValidRefreshToken(String tokenValue, UserPrincipal principal,
+                                       AuthenticationDetails details) throws RefreshTokenException {
+        RefreshToken findRefreshToken = refreshTokenRepository.findByTokenValue(tokenValue)
+                .orElseThrow(() -> new RefreshTokenException("No Such RefreshToken"));
+        return findRefreshToken.getUserId().equals(principal.id())
+                && findRefreshToken.getClientIp().equals(details.getClientIp())
+                && findRefreshToken.getUserAgent().equals(details.getUserAgent());
+    }
+
+    @Transactional
+    public String updateRefreshToken(UserPrincipal principal, AuthenticationDetails details) {
+        Long userId = principal.id();
+        String clientIp = details.getClientIp();
+        String userAgent = details.getUserAgent();
+
+        Optional<RefreshToken> refreshToken = refreshTokenRepository.findByClientIpAndUserAgent(
+                clientIp, userAgent);
+        String refreshTokenValue = UUID.randomUUID().toString();
+        if (refreshToken.isPresent()) {
+            refreshToken.get().update(userId, refreshTokenValue);
+            refreshTokenRepository.saveAndFlush(refreshToken.get());
+        } else {
+            refreshTokenRepository.saveAndFlush(
+                    RefreshToken.create(userId, refreshTokenValue, clientIp, userAgent));
+        }
+
+        return refreshTokenValue;
+    }
+}

--- a/src/main/java/com/fastcampus/mini9/config/security/service/RefreshTokenService.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/service/RefreshTokenService.java
@@ -43,7 +43,7 @@ public class RefreshTokenService {
             refreshTokenRepository.saveAndFlush(refreshToken.get());
         } else {
             refreshTokenRepository.saveAndFlush(
-                RefreshToken.create(userId, refreshTokenValue, clientIp, userAgent));
+                new RefreshToken(userId, refreshTokenValue, clientIp, userAgent));
         }
 
         return refreshTokenValue;

--- a/src/main/java/com/fastcampus/mini9/config/security/service/RefreshTokenService.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/service/RefreshTokenService.java
@@ -1,16 +1,14 @@
 package com.fastcampus.mini9.config.security.service;
 
-import java.util.Optional;
-import java.util.UUID;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.fastcampus.mini9.config.security.exception.RefreshTokenException;
 import com.fastcampus.mini9.config.security.token.AuthenticationDetails;
 import com.fastcampus.mini9.config.security.token.UserPrincipal;
 import com.fastcampus.mini9.domain.member.entity.RefreshToken;
 import com.fastcampus.mini9.domain.member.repository.RefreshTokenRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
@@ -25,10 +23,10 @@ public class RefreshTokenService {
     public boolean isValidRefreshToken(String tokenValue, UserPrincipal principal,
                                        AuthenticationDetails details) throws RefreshTokenException {
         RefreshToken findRefreshToken = refreshTokenRepository.findByTokenValue(tokenValue)
-                .orElseThrow(() -> new RefreshTokenException("No Such RefreshToken"));
+            .orElseThrow(() -> new RefreshTokenException("No Such RefreshToken"));
         return findRefreshToken.getUserId().equals(principal.id())
-                && findRefreshToken.getClientIp().equals(details.getClientIp())
-                && findRefreshToken.getUserAgent().equals(details.getUserAgent());
+            && findRefreshToken.getClientIp().equals(details.getClientIp())
+            && findRefreshToken.getUserAgent().equals(details.getUserAgent());
     }
 
     @Transactional
@@ -38,14 +36,14 @@ public class RefreshTokenService {
         String userAgent = details.getUserAgent();
 
         Optional<RefreshToken> refreshToken = refreshTokenRepository.findByClientIpAndUserAgent(
-                clientIp, userAgent);
+            clientIp, userAgent);
         String refreshTokenValue = UUID.randomUUID().toString();
         if (refreshToken.isPresent()) {
             refreshToken.get().update(userId, refreshTokenValue);
             refreshTokenRepository.saveAndFlush(refreshToken.get());
         } else {
             refreshTokenRepository.saveAndFlush(
-                    RefreshToken.create(userId, refreshTokenValue, clientIp, userAgent));
+                RefreshToken.create(userId, refreshTokenValue, clientIp, userAgent));
         }
 
         return refreshTokenValue;

--- a/src/main/java/com/fastcampus/mini9/config/security/service/UserDetailsWithId.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/service/UserDetailsWithId.java
@@ -1,0 +1,29 @@
+package com.fastcampus.mini9.config.security.service;
+
+import java.util.Collection;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+public class UserDetailsWithId extends User {
+
+    private final Long userId;
+
+    public UserDetailsWithId(Long userId, String username, String password,
+        Collection<? extends GrantedAuthority> authorities) {
+        super(username, password, authorities);
+        this.userId = userId;
+    }
+
+    public UserDetailsWithId(Long userId, String username, String password, boolean enabled,
+        boolean accountNonExpired, boolean credentialsNonExpired, boolean accountNonLocked,
+        Collection<? extends GrantedAuthority> authorities) {
+        super(username, password, enabled, accountNonExpired, credentialsNonExpired,
+            accountNonLocked, authorities);
+        this.userId = userId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+}

--- a/src/main/java/com/fastcampus/mini9/config/security/service/UserDetailsWithId.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/service/UserDetailsWithId.java
@@ -1,7 +1,6 @@
 package com.fastcampus.mini9.config.security.service;
 
 import java.util.Collection;
-
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 
@@ -10,14 +9,15 @@ public class UserDetailsWithId extends User {
     private final Long userId;
 
     public UserDetailsWithId(Long userId, String username, String password,
-        Collection<? extends GrantedAuthority> authorities) {
+                             Collection<? extends GrantedAuthority> authorities) {
         super(username, password, authorities);
         this.userId = userId;
     }
 
     public UserDetailsWithId(Long userId, String username, String password, boolean enabled,
-        boolean accountNonExpired, boolean credentialsNonExpired, boolean accountNonLocked,
-        Collection<? extends GrantedAuthority> authorities) {
+                             boolean accountNonExpired, boolean credentialsNonExpired,
+                             boolean accountNonLocked,
+                             Collection<? extends GrantedAuthority> authorities) {
         super(username, password, enabled, accountNonExpired, credentialsNonExpired,
             accountNonLocked, authorities);
         this.userId = userId;

--- a/src/main/java/com/fastcampus/mini9/config/security/token/AjaxAuthenticationToken.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/token/AjaxAuthenticationToken.java
@@ -1,0 +1,61 @@
+package com.fastcampus.mini9.config.security.token;
+
+import java.util.Collection;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.util.Assert;
+
+public class AjaxAuthenticationToken extends AbstractAuthenticationToken {
+
+    private final Object principal;
+    private Object credentials;
+
+    public AjaxAuthenticationToken(Object principal, Object credentials) {
+        super(null);
+        this.principal = principal;
+        this.credentials = credentials;
+        setAuthenticated(false);
+    }
+
+    public AjaxAuthenticationToken(Object principal, Object credentials,
+        Collection<? extends GrantedAuthority> authorities) {
+        super(authorities);
+        this.principal = principal;
+        this.credentials = credentials;
+        super.setAuthenticated(true); // must use super, as we override
+    }
+
+    public static AjaxAuthenticationToken unauthenticated(Object principal, Object credentials) {
+        return new AjaxAuthenticationToken(principal, credentials);
+    }
+
+    public static AjaxAuthenticationToken authenticated(Object principal, Object credentials,
+        Collection<? extends GrantedAuthority> authorities) {
+        return new AjaxAuthenticationToken(principal, credentials, authorities);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return this.credentials;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return this.principal;
+    }
+
+    @Override
+    public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+        Assert.isTrue(!isAuthenticated,
+            "Cannot set this token to trusted"
+                + " - use constructor which takes a GrantedAuthority list instead");
+        super.setAuthenticated(false);
+    }
+
+    @Override
+    public void eraseCredentials() {
+        super.eraseCredentials();
+        this.credentials = null;
+    }
+}

--- a/src/main/java/com/fastcampus/mini9/config/security/token/AjaxAuthenticationToken.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/token/AjaxAuthenticationToken.java
@@ -1,7 +1,6 @@
 package com.fastcampus.mini9.config.security.token;
 
 import java.util.Collection;
-
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.util.Assert;
@@ -19,7 +18,7 @@ public class AjaxAuthenticationToken extends AbstractAuthenticationToken {
     }
 
     public AjaxAuthenticationToken(Object principal, Object credentials,
-        Collection<? extends GrantedAuthority> authorities) {
+                                   Collection<? extends GrantedAuthority> authorities) {
         super(authorities);
         this.principal = principal;
         this.credentials = credentials;
@@ -31,7 +30,7 @@ public class AjaxAuthenticationToken extends AbstractAuthenticationToken {
     }
 
     public static AjaxAuthenticationToken authenticated(Object principal, Object credentials,
-        Collection<? extends GrantedAuthority> authorities) {
+                                                        Collection<? extends GrantedAuthority> authorities) {
         return new AjaxAuthenticationToken(principal, credentials, authorities);
     }
 

--- a/src/main/java/com/fastcampus/mini9/config/security/token/AuthenticationDetails.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/token/AuthenticationDetails.java
@@ -1,0 +1,79 @@
+package com.fastcampus.mini9.config.security.token;
+
+import java.util.Objects;
+
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public class AuthenticationDetails extends WebAuthenticationDetails {
+
+    private final String clientIp;
+    private final String userAgent;
+
+    public AuthenticationDetails(HttpServletRequest request) {
+        super(request);
+        this.clientIp = extractClientIp(request);
+        this.userAgent = request.getHeader("User-Agent");
+    }
+
+    public String getClientIp() {
+        return clientIp;
+    }
+
+    public String getUserAgent() {
+        return userAgent;
+    }
+
+    private static String extractClientIp(HttpServletRequest request) {
+        String ip = request.getHeader("X-Forwarded-For");
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("Proxy-Client-IP");
+        }
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("WL-Proxy-Client-IP");
+        }
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("HTTP_CLIENT_IP");
+        }
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("HTTP_X_FORWARDED_FOR");
+        }
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getRemoteAddr();
+        }
+        return ip;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        AuthenticationDetails that = (AuthenticationDetails) o;
+        return Objects.equals(clientIp, that.clientIp) && Objects.equals(userAgent,
+            that.userAgent);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), clientIp, userAgent);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(getClass().getSimpleName()).append(" [");
+        sb.append("RemoteIpAddress=").append(this.getRemoteAddress()).append(", ");
+        sb.append("SessionId=").append(this.getSessionId()).append(", ");
+        sb.append("clientIp=").append(this.getClientIp()).append(", ");
+        sb.append("userAgent=").append(this.getClientIp()).append("]");
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/fastcampus/mini9/config/security/token/AuthenticationDetails.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/token/AuthenticationDetails.java
@@ -1,10 +1,8 @@
 package com.fastcampus.mini9.config.security.token;
 
-import java.util.Objects;
-
-import org.springframework.security.web.authentication.WebAuthenticationDetails;
-
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Objects;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
 
 public class AuthenticationDetails extends WebAuthenticationDetails {
 
@@ -15,14 +13,6 @@ public class AuthenticationDetails extends WebAuthenticationDetails {
         super(request);
         this.clientIp = extractClientIp(request);
         this.userAgent = request.getHeader("User-Agent");
-    }
-
-    public String getClientIp() {
-        return clientIp;
-    }
-
-    public String getUserAgent() {
-        return userAgent;
     }
 
     private static String extractClientIp(HttpServletRequest request) {
@@ -43,6 +33,14 @@ public class AuthenticationDetails extends WebAuthenticationDetails {
             ip = request.getRemoteAddr();
         }
         return ip;
+    }
+
+    public String getClientIp() {
+        return clientIp;
+    }
+
+    public String getUserAgent() {
+        return userAgent;
     }
 
     @Override

--- a/src/main/java/com/fastcampus/mini9/config/security/token/JwtAuthenticationToken.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/token/JwtAuthenticationToken.java
@@ -1,7 +1,6 @@
 package com.fastcampus.mini9.config.security.token;
 
 import java.util.Collection;
-
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.util.Assert;
@@ -22,7 +21,7 @@ public class JwtAuthenticationToken extends AbstractAuthenticationToken {
     }
 
     public JwtAuthenticationToken(Object principal, Object credentials,
-        Collection<? extends GrantedAuthority> authorities) {
+                                  Collection<? extends GrantedAuthority> authorities) {
         super(authorities);
         this.principal = principal;
         this.credentials = credentials;
@@ -30,8 +29,9 @@ public class JwtAuthenticationToken extends AbstractAuthenticationToken {
     }
 
     public JwtAuthenticationToken(Object principal, Object credentials,
-        Collection<? extends GrantedAuthority> authorities, String newAccessToken,
-        String newRefreshToken) {
+                                  Collection<? extends GrantedAuthority> authorities,
+                                  String newAccessToken,
+                                  String newRefreshToken) {
         super(authorities);
         this.principal = principal;
         this.credentials = credentials;
@@ -46,13 +46,14 @@ public class JwtAuthenticationToken extends AbstractAuthenticationToken {
     }
 
     public static JwtAuthenticationToken authenticated(Object principal, Object credentials,
-        Collection<? extends GrantedAuthority> authorities) {
+                                                       Collection<? extends GrantedAuthority> authorities) {
         return new JwtAuthenticationToken(principal, credentials, authorities);
     }
 
     public static JwtAuthenticationToken authenticated(Object principal, Object credentials,
-        Collection<? extends GrantedAuthority> authorities, String newAccessToken,
-        String newRefreshToken) {
+                                                       Collection<? extends GrantedAuthority> authorities,
+                                                       String newAccessToken,
+                                                       String newRefreshToken) {
         return new JwtAuthenticationToken(principal, credentials, authorities, newAccessToken,
             newRefreshToken);
     }

--- a/src/main/java/com/fastcampus/mini9/config/security/token/JwtAuthenticationToken.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/token/JwtAuthenticationToken.java
@@ -1,0 +1,95 @@
+package com.fastcampus.mini9.config.security.token;
+
+import java.util.Collection;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.util.Assert;
+
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+
+    private final Object principal;
+    private Object credentials;
+    private boolean isRegenerated = false;
+    private String newAccessToken;
+    private String newRefreshToken;
+
+    public JwtAuthenticationToken(Object principal, Object credentials) {
+        super(null);
+        this.principal = principal;
+        this.credentials = credentials;
+        setAuthenticated(false);
+    }
+
+    public JwtAuthenticationToken(Object principal, Object credentials,
+        Collection<? extends GrantedAuthority> authorities) {
+        super(authorities);
+        this.principal = principal;
+        this.credentials = credentials;
+        super.setAuthenticated(true); // must use super, as we override
+    }
+
+    public JwtAuthenticationToken(Object principal, Object credentials,
+        Collection<? extends GrantedAuthority> authorities, String newAccessToken,
+        String newRefreshToken) {
+        super(authorities);
+        this.principal = principal;
+        this.credentials = credentials;
+        this.isRegenerated = true;
+        this.newAccessToken = newAccessToken;
+        this.newRefreshToken = newRefreshToken;
+        super.setAuthenticated(true); // must use super, as we override
+    }
+
+    public static JwtAuthenticationToken unauthenticated(Object principal, Object credentials) {
+        return new JwtAuthenticationToken(principal, credentials);
+    }
+
+    public static JwtAuthenticationToken authenticated(Object principal, Object credentials,
+        Collection<? extends GrantedAuthority> authorities) {
+        return new JwtAuthenticationToken(principal, credentials, authorities);
+    }
+
+    public static JwtAuthenticationToken authenticated(Object principal, Object credentials,
+        Collection<? extends GrantedAuthority> authorities, String newAccessToken,
+        String newRefreshToken) {
+        return new JwtAuthenticationToken(principal, credentials, authorities, newAccessToken,
+            newRefreshToken);
+    }
+
+    public boolean isRegenerated() {
+        return this.isRegenerated;
+    }
+
+    public String getNewAccessToken() {
+        return newAccessToken;
+    }
+
+    public String getNewRefreshToken() {
+        return newRefreshToken;
+    }
+
+    @Override
+    public Object getCredentials() {
+        return this.credentials;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return this.principal;
+    }
+
+    @Override
+    public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+        Assert.isTrue(!isAuthenticated,
+            "Cannot set this token to trusted"
+                + " - use constructor which takes a GrantedAuthority list instead");
+        super.setAuthenticated(false);
+    }
+
+    @Override
+    public void eraseCredentials() {
+        super.eraseCredentials();
+        this.credentials = null;
+    }
+}

--- a/src/main/java/com/fastcampus/mini9/config/security/token/UserPrincipal.java
+++ b/src/main/java/com/fastcampus/mini9/config/security/token/UserPrincipal.java
@@ -1,9 +1,8 @@
 package com.fastcampus.mini9.config.security.token;
 
-import org.springframework.security.core.AuthenticatedPrincipal;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.security.core.AuthenticatedPrincipal;
 
 /**
  * AuthenticationPrincipalArgumentResolver가 바인딩한 결과로 뱉어주는 객체.

--- a/src/main/java/com/fastcampus/mini9/domain/accommodation/entity/Location.java
+++ b/src/main/java/com/fastcampus/mini9/domain/accommodation/entity/Location.java
@@ -1,9 +1,12 @@
 package com.fastcampus.mini9.domain.accommodation.entity;
 
 import jakarta.persistence.Embeddable;
+import jakarta.persistence.OneToOne;
 
 @Embeddable
 public class Location {
+	@OneToOne
 	private Region region;
+	@OneToOne
 	private District district;
 }

--- a/src/main/java/com/fastcampus/mini9/domain/member/controller/MemberController.java
+++ b/src/main/java/com/fastcampus/mini9/domain/member/controller/MemberController.java
@@ -1,0 +1,31 @@
+package com.fastcampus.mini9.domain.member.controller;
+
+import com.fastcampus.mini9.common.response.DataResponseBody;
+import com.fastcampus.mini9.domain.member.controller.dto.MemberDtoMapper;
+import com.fastcampus.mini9.domain.member.controller.dto.request.SignupRequestDto;
+import com.fastcampus.mini9.domain.member.controller.dto.response.MemberSaveResponseDto;
+import com.fastcampus.mini9.domain.member.service.MemberService;
+import com.fastcampus.mini9.domain.member.service.dto.response.MemberDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+    private final MemberDtoMapper mapper;
+
+    @PostMapping("/sign-up")
+    public DataResponseBody<MemberSaveResponseDto> signUp(
+        @RequestBody @Valid SignupRequestDto request
+    ) {
+        MemberDto response = memberService.save(mapper.signupTomMemberSave(request));
+        return DataResponseBody.success(mapper.memberToMemberSaveResponse(response));
+    }
+}

--- a/src/main/java/com/fastcampus/mini9/domain/member/controller/dto/MemberDtoMapper.java
+++ b/src/main/java/com/fastcampus/mini9/domain/member/controller/dto/MemberDtoMapper.java
@@ -1,0 +1,22 @@
+package com.fastcampus.mini9.domain.member.controller.dto;
+
+import com.fastcampus.mini9.domain.member.controller.dto.request.SignupRequestDto;
+import com.fastcampus.mini9.domain.member.controller.dto.response.MemberSaveResponseDto;
+import com.fastcampus.mini9.domain.member.service.dto.request.MemberSaveDto;
+import com.fastcampus.mini9.domain.member.service.dto.response.MemberDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+
+/**
+ * 사용방법
+ * <p>
+ * / @Mapping(source  = "numberOfSeats", target = "seatCount")
+ * CarDto carToCarDto(Car car);
+ */
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
+public interface MemberDtoMapper {
+
+    MemberSaveDto signupTomMemberSave(SignupRequestDto dto);
+
+    MemberSaveResponseDto memberToMemberSaveResponse(MemberDto dto);
+}

--- a/src/main/java/com/fastcampus/mini9/domain/member/controller/dto/request/LoginRequestDto.java
+++ b/src/main/java/com/fastcampus/mini9/domain/member/controller/dto/request/LoginRequestDto.java
@@ -1,7 +1,8 @@
 package com.fastcampus.mini9.domain.member.controller.dto.request;
 
 public record LoginRequestDto(
-	String email,
-	String password
+    String email,
+    String pwd
 ) {
+
 }

--- a/src/main/java/com/fastcampus/mini9/domain/member/controller/dto/request/LoginRequestDto.java
+++ b/src/main/java/com/fastcampus/mini9/domain/member/controller/dto/request/LoginRequestDto.java
@@ -1,7 +1,8 @@
 package com.fastcampus.mini9.domain.member.controller.dto.request;
 
 public record LoginRequestDto(
-	String email,
-	String password
+    String email,
+    String password
 ) {
+
 }

--- a/src/main/java/com/fastcampus/mini9/domain/member/controller/dto/request/LoginRequestDto.java
+++ b/src/main/java/com/fastcampus/mini9/domain/member/controller/dto/request/LoginRequestDto.java
@@ -2,6 +2,6 @@ package com.fastcampus.mini9.domain.member.controller.dto.request;
 
 public record LoginRequestDto(
 	String email,
-	String password
+	String pwd
 ) {
 }

--- a/src/main/java/com/fastcampus/mini9/domain/member/controller/dto/request/LoginRequestDto.java
+++ b/src/main/java/com/fastcampus/mini9/domain/member/controller/dto/request/LoginRequestDto.java
@@ -1,0 +1,7 @@
+package com.fastcampus.mini9.domain.member.controller.dto.request;
+
+public record LoginRequestDto(
+	String email,
+	String password
+) {
+}

--- a/src/main/java/com/fastcampus/mini9/domain/member/controller/dto/request/SignupRequestDto.java
+++ b/src/main/java/com/fastcampus/mini9/domain/member/controller/dto/request/SignupRequestDto.java
@@ -1,0 +1,23 @@
+package com.fastcampus.mini9.domain.member.controller.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+
+public record SignupRequestDto(
+    @NotBlank(message = "이메일은 필수 입력 사항입니다.")
+    @Email(message = "이메일 형식으로 입력해 주세요.")
+    String email,
+
+    @NotBlank(message = "패스워드는 필수 입력 사항입니다.")
+    @Size(min = 8, message = "8자리 이상의 비밀번호를 입력해 주세요")
+    String pwd,
+
+    @NotBlank(message = "이름은 필수 입력 사항입니다.")
+    String name,
+
+    LocalDate birthday
+) {
+
+}

--- a/src/main/java/com/fastcampus/mini9/domain/member/controller/dto/response/MemberSaveResponseDto.java
+++ b/src/main/java/com/fastcampus/mini9/domain/member/controller/dto/response/MemberSaveResponseDto.java
@@ -1,0 +1,12 @@
+package com.fastcampus.mini9.domain.member.controller.dto.response;
+
+import java.time.LocalDate;
+
+public record MemberSaveResponseDto(
+    Long id,
+    String email,
+    String name,
+    LocalDate birthday
+) {
+
+}

--- a/src/main/java/com/fastcampus/mini9/domain/member/entity/Member.java
+++ b/src/main/java/com/fastcampus/mini9/domain/member/entity/Member.java
@@ -1,11 +1,10 @@
 package com.fastcampus.mini9.domain.member.entity;
 
-import java.time.LocalDate;
-
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,11 +13,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Member {
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
-	private String email;
-	private String pwd;
-	private String name;
-	private LocalDate birthday;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String email;
+    private String pwd;
+    private String name;
+    private LocalDate birthday;
 }

--- a/src/main/java/com/fastcampus/mini9/domain/member/entity/Member.java
+++ b/src/main/java/com/fastcampus/mini9/domain/member/entity/Member.java
@@ -1,12 +1,12 @@
 package com.fastcampus.mini9.domain.member.entity;
 
-import java.time.LocalDate;
-
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.time.LocalDate;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -14,11 +14,20 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Member {
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
-	private String email;
-	private String pwd;
-	private String name;
-	private LocalDate birthday;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String email;
+    private String pwd;
+    private String name;
+    private LocalDate birthday;
+
+    @Builder
+    private Member(String email, String pwd, String name, LocalDate birthday) {
+        this.email = email;
+        this.pwd = pwd;
+        this.name = name;
+        this.birthday = birthday;
+    }
 }

--- a/src/main/java/com/fastcampus/mini9/domain/member/entity/RefreshToken.java
+++ b/src/main/java/com/fastcampus/mini9/domain/member/entity/RefreshToken.java
@@ -37,13 +37,13 @@ public class RefreshToken {
         this.userAgent = userAgent;
     }
 
+    public static RefreshToken create(Long userId, String tokenValue, String ipAdd,
+                                      String userAgent) {
+        return new RefreshToken(userId, tokenValue, ipAdd, userAgent);
+    }
+
     public void update(Long userId, String tokenValue) {
         this.userId = userId;
         this.tokenValue = tokenValue;
-    }
-
-    public static RefreshToken create(Long userId, String tokenValue, String ipAdd,
-        String userAgent) {
-        return new RefreshToken(userId, tokenValue, ipAdd, userAgent);
     }
 }

--- a/src/main/java/com/fastcampus/mini9/domain/member/entity/RefreshToken.java
+++ b/src/main/java/com/fastcampus/mini9/domain/member/entity/RefreshToken.java
@@ -1,0 +1,49 @@
+package com.fastcampus.mini9.domain.member.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(indexes = @Index(columnList = "tokenValue"))
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    @Column(unique = true)
+    private String tokenValue;
+
+    private String clientIp;
+
+    private String userAgent;
+
+    public RefreshToken(Long userId, String tokenValue, String clientIp, String userAgent) {
+        this.userId = userId;
+        this.tokenValue = tokenValue;
+        this.clientIp = clientIp;
+        this.userAgent = userAgent;
+    }
+
+    public void update(Long userId, String tokenValue) {
+        this.userId = userId;
+        this.tokenValue = tokenValue;
+    }
+
+    public static RefreshToken create(Long userId, String tokenValue, String ipAdd,
+        String userAgent) {
+        return new RefreshToken(userId, tokenValue, ipAdd, userAgent);
+    }
+}

--- a/src/main/java/com/fastcampus/mini9/domain/member/entity/RefreshToken.java
+++ b/src/main/java/com/fastcampus/mini9/domain/member/entity/RefreshToken.java
@@ -37,11 +37,6 @@ public class RefreshToken {
         this.userAgent = userAgent;
     }
 
-    public static RefreshToken create(Long userId, String tokenValue, String ipAdd,
-                                      String userAgent) {
-        return new RefreshToken(userId, tokenValue, ipAdd, userAgent);
-    }
-
     public void update(Long userId, String tokenValue) {
         this.userId = userId;
         this.tokenValue = tokenValue;

--- a/src/main/java/com/fastcampus/mini9/domain/member/exception/ExistsArgumentException.java
+++ b/src/main/java/com/fastcampus/mini9/domain/member/exception/ExistsArgumentException.java
@@ -1,0 +1,15 @@
+package com.fastcampus.mini9.domain.member.exception;
+
+import com.fastcampus.mini9.common.exception.BaseException;
+import com.fastcampus.mini9.common.exception.ErrorCode;
+
+public class ExistsArgumentException extends BaseException {
+
+    public ExistsArgumentException() {
+        super(ErrorCode.ExistsArgument.getMsg(), ErrorCode.ExistsArgument);
+    }
+
+    public ExistsArgumentException(String message) {
+        super(message, ErrorCode.ExistsArgument);
+    }
+}

--- a/src/main/java/com/fastcampus/mini9/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/fastcampus/mini9/domain/member/repository/MemberRepository.java
@@ -1,11 +1,10 @@
 package com.fastcampus.mini9.domain.member.repository;
 
+import com.fastcampus.mini9.domain.member.entity.Member;
 import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.fastcampus.mini9.domain.member.entity.Member;
-
 public interface MemberRepository extends JpaRepository<Member, Long> {
-	Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/fastcampus/mini9/domain/member/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/fastcampus/mini9/domain/member/repository/RefreshTokenRepository.java
@@ -1,0 +1,16 @@
+package com.fastcampus.mini9.domain.member.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.fastcampus.mini9.domain.member.entity.RefreshToken;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByClientIpAndUserAgent(String clientIp, String userAgent);
+
+    Optional<RefreshToken> findByTokenValue(String tokenValue);
+}

--- a/src/main/java/com/fastcampus/mini9/domain/member/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/fastcampus/mini9/domain/member/repository/RefreshTokenRepository.java
@@ -1,11 +1,9 @@
 package com.fastcampus.mini9.domain.member.repository;
 
+import com.fastcampus.mini9.domain.member.entity.RefreshToken;
 import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
-import com.fastcampus.mini9.domain.member.entity.RefreshToken;
 
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {

--- a/src/main/java/com/fastcampus/mini9/domain/member/service/MemberService.java
+++ b/src/main/java/com/fastcampus/mini9/domain/member/service/MemberService.java
@@ -1,0 +1,28 @@
+package com.fastcampus.mini9.domain.member.service;
+
+import com.fastcampus.mini9.domain.member.entity.Member;
+import com.fastcampus.mini9.domain.member.exception.ExistsArgumentException;
+import com.fastcampus.mini9.domain.member.repository.MemberRepository;
+import com.fastcampus.mini9.domain.member.service.dto.request.MemberSaveDto;
+import com.fastcampus.mini9.domain.member.service.dto.response.MemberDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public MemberDto save(MemberSaveDto dto) {
+        if (memberRepository.findByEmail(dto.email()).isPresent()) {
+            throw new ExistsArgumentException("이미 존재하는 이메일입니다.");
+        }
+        String encodePassword = passwordEncoder.encode(dto.pwd());
+        Member member = dto.toEntity(encodePassword);
+        Member saveMember = memberRepository.save(member);
+        return MemberDto.toDto(saveMember);
+    }
+}

--- a/src/main/java/com/fastcampus/mini9/domain/member/service/dto/request/MemberSaveDto.java
+++ b/src/main/java/com/fastcampus/mini9/domain/member/service/dto/request/MemberSaveDto.java
@@ -1,0 +1,21 @@
+package com.fastcampus.mini9.domain.member.service.dto.request;
+
+import com.fastcampus.mini9.domain.member.entity.Member;
+import java.time.LocalDate;
+
+public record MemberSaveDto(
+    String email,
+    String pwd,
+    String name,
+    LocalDate birthday
+) {
+
+    public Member toEntity(String encodePassword) {
+        return Member.builder()
+            .email(email)
+            .pwd(encodePassword)
+            .name(name)
+            .birthday(birthday)
+            .build();
+    }
+}

--- a/src/main/java/com/fastcampus/mini9/domain/member/service/dto/response/MemberDto.java
+++ b/src/main/java/com/fastcampus/mini9/domain/member/service/dto/response/MemberDto.java
@@ -1,0 +1,23 @@
+package com.fastcampus.mini9.domain.member.service.dto.response;
+
+import com.fastcampus.mini9.domain.member.entity.Member;
+import java.time.LocalDate;
+import lombok.Builder;
+
+@Builder
+public record MemberDto(
+    Long id,
+    String email,
+    String name,
+    LocalDate birthday
+) {
+
+    public static MemberDto toDto(Member member) {
+        return MemberDto.builder()
+            .id(member.getId())
+            .email(member.getEmail())
+            .name(member.getName())
+            .birthday(member.getBirthday())
+            .build();
+    }
+}


### PR DESCRIPTION
- 회원가입 시 중복된 이메일이 들어올 때 처리할 수 있는 커스텀 예외 ExistsArgumentException 생성.
- access-token은 Authorization 헤더를 통해서, refresh-token은 쿠키를 통해 얻어오도록 수정.
- 로그인 응답 반환에서 access-token 값을 포함해서 반환하도록 수정.
- 쿠키 생성 시 access-token은 secure 처리 없이, refresh-token은 secure 설정 포함한 쿠키를 생성하도록 설정.