### PR TITLE
재고 스케줄러 구현

### DIFF
--- a/src/main/java/com/fastcampus/mini9/Mini9Application.java
+++ b/src/main/java/com/fastcampus/mini9/Mini9Application.java
@@ -2,10 +2,12 @@ package com.fastcampus.mini9;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableAsync
 public class Mini9Application {
 
     public static void main(String[] args) {

--- a/src/main/java/com/fastcampus/mini9/Mini9Application.java
+++ b/src/main/java/com/fastcampus/mini9/Mini9Application.java
@@ -2,8 +2,10 @@ package com.fastcampus.mini9;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class Mini9Application {
 
     public static void main(String[] args) {

--- a/src/main/java/com/fastcampus/mini9/common/util/schduler/StockScheduler.java
+++ b/src/main/java/com/fastcampus/mini9/common/util/schduler/StockScheduler.java
@@ -1,0 +1,28 @@
+package com.fastcampus.mini9.common.util.schduler;
+
+import jakarta.annotation.PostConstruct;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StockScheduler {
+
+    private static final int INIT_MONTH = 3;
+
+    private final StockService stockService;
+
+
+    @PostConstruct
+    public void initStock() {
+        stockService.createStocks(LocalDate.now(), LocalDate.now().plusMonths(INIT_MONTH));
+    }
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void dailyStockGeneration() {
+        LocalDate startDate = LocalDate.now().plusMonths(INIT_MONTH);
+        stockService.createStocks(startDate, startDate.plusDays(1));
+    }
+}

--- a/src/main/java/com/fastcampus/mini9/common/util/schduler/StockScheduler.java
+++ b/src/main/java/com/fastcampus/mini9/common/util/schduler/StockScheduler.java
@@ -21,8 +21,7 @@ public class StockScheduler {
     }
 
     @Scheduled(cron = "0 0 0 * * *")
-    public void dailyStockGeneration() {
-        LocalDate startDate = LocalDate.now().plusMonths(INIT_MONTH);
-        stockService.createStocks(startDate, startDate.plusDays(1));
+    public void dailyStock() {
+        stockService.createStocks(LocalDate.now().plusMonths(INIT_MONTH));
     }
 }

--- a/src/main/java/com/fastcampus/mini9/common/util/schduler/StockScheduler.java
+++ b/src/main/java/com/fastcampus/mini9/common/util/schduler/StockScheduler.java
@@ -23,5 +23,6 @@ public class StockScheduler {
     @Scheduled(cron = "0 0 0 * * *")
     public void dailyStock() {
         stockService.createStocks(LocalDate.now().plusMonths(INIT_MONTH));
+        stockService.deleteBeforeStock(LocalDate.now());
     }
 }

--- a/src/main/java/com/fastcampus/mini9/common/util/schduler/StockScheduler.java
+++ b/src/main/java/com/fastcampus/mini9/common/util/schduler/StockScheduler.java
@@ -18,7 +18,7 @@ public class StockScheduler {
     @Async
     @PostConstruct
     public void initStock() {
-        stockService.createStocks(LocalDate.now(), LocalDate.now().plusDays(1));
+        stockService.createStocks(LocalDate.now(), LocalDate.now().plusMonths(INIT_MONTH));
     }
 
     @Async

--- a/src/main/java/com/fastcampus/mini9/common/util/schduler/StockScheduler.java
+++ b/src/main/java/com/fastcampus/mini9/common/util/schduler/StockScheduler.java
@@ -1,6 +1,5 @@
 package com.fastcampus.mini9.common.util.schduler;
 
-import jakarta.annotation.PostConstruct;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
@@ -11,21 +10,15 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class StockScheduler {
 
-    private static final int INIT_MONTH = 3;
+    private static final int INIT_MONTH = 2;
 
     private final StockService stockService;
 
     @Async
-    @PostConstruct
-    public void initStock() {
-        stockService.createStocks(LocalDate.now(), LocalDate.now().plusMonths(INIT_MONTH));
-    }
-
-    @Async
-    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "00 00 00 * * *")
     public void dailyStock() {
         LocalDate startDate = LocalDate.now().plusMonths(INIT_MONTH);
-        stockService.createStocks(startDate);
+        stockService.createStocks(startDate, startDate.plusDays(1));
         stockService.deleteBeforeStock(LocalDate.now());
     }
 }

--- a/src/main/java/com/fastcampus/mini9/common/util/schduler/StockScheduler.java
+++ b/src/main/java/com/fastcampus/mini9/common/util/schduler/StockScheduler.java
@@ -3,6 +3,7 @@ package com.fastcampus.mini9.common.util.schduler;
 import jakarta.annotation.PostConstruct;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -14,12 +15,13 @@ public class StockScheduler {
 
     private final StockService stockService;
 
-
+    @Async
     @PostConstruct
     public void initStock() {
         stockService.createStocks(LocalDate.now(), LocalDate.now().plusMonths(INIT_MONTH));
     }
 
+    @Async
     @Scheduled(cron = "0 0 0 * * *")
     public void dailyStock() {
         stockService.createStocks(LocalDate.now().plusMonths(INIT_MONTH));

--- a/src/main/java/com/fastcampus/mini9/common/util/schduler/StockScheduler.java
+++ b/src/main/java/com/fastcampus/mini9/common/util/schduler/StockScheduler.java
@@ -18,13 +18,14 @@ public class StockScheduler {
     @Async
     @PostConstruct
     public void initStock() {
-        stockService.createStocks(LocalDate.now(), LocalDate.now().plusMonths(INIT_MONTH));
+        stockService.createStocks(LocalDate.now(), LocalDate.now().plusDays(1));
     }
 
     @Async
     @Scheduled(cron = "0 0 0 * * *")
     public void dailyStock() {
-        stockService.createStocks(LocalDate.now().plusMonths(INIT_MONTH));
+        LocalDate startDate = LocalDate.now().plusMonths(INIT_MONTH);
+        stockService.createStocks(startDate);
         stockService.deleteBeforeStock(LocalDate.now());
     }
 }

--- a/src/main/java/com/fastcampus/mini9/common/util/schduler/StockService.java
+++ b/src/main/java/com/fastcampus/mini9/common/util/schduler/StockService.java
@@ -25,32 +25,11 @@ public class StockService {
         List<Room> rooms = roomRepository.findAll();
         rooms.parallelStream().forEach(room ->
             startDate.datesUntil(endDate).forEach(date ->
-                createStockForDateWithoutExistsCheck(room, date)));
+                saveStock(room, date)));
     }
 
     @Async
-    public void createStocks(LocalDate startDate) {
-        LocalDate endDate = startDate.plusDays(1);
-        List<Room> rooms = roomRepository.findAll();
-        rooms.parallelStream().forEach(room ->
-            startDate.datesUntil(endDate).forEach(date ->
-                createStockForDate(room, date)));
-    }
-
-    @Async
-    public void createStockForDate(Room room, LocalDate date) {
-        if (!stockExists(room, date)) {
-            Stock stock = Stock.builder()
-                .room(room)
-                .date(date)
-                .quantity(room.getNumberOfRoom())
-                .build();
-            stockRepository.save(stock);
-        }
-    }
-
-    @Async
-    public void createStockForDateWithoutExistsCheck(Room room, LocalDate date) {
+    public void saveStock(Room room, LocalDate date) {
         Stock stock = Stock.builder()
             .room(room)
             .date(date)
@@ -59,10 +38,7 @@ public class StockService {
         stockRepository.save(stock);
     }
 
-    private boolean stockExists(Room room, LocalDate date) {
-        return stockRepository.existsByRoomAndDate(room, date);
-    }
-
+    @Async
     public void deleteBeforeStock(LocalDate date) {
         stockRepository.deleteStocksBeforeDate(date);
     }

--- a/src/main/java/com/fastcampus/mini9/common/util/schduler/StockService.java
+++ b/src/main/java/com/fastcampus/mini9/common/util/schduler/StockService.java
@@ -32,4 +32,23 @@ public class StockService {
             }
         }
     }
+    public void createStocks(LocalDate startDate) {
+        LocalDate endDate = startDate.plusDays(1);
+        List<Room> rooms = roomRepository.findAll();
+        for (Room room : rooms) {
+            for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
+                if (!stockExists(room, date)) {
+                    Stock stock = Stock.builder()
+                        .room(room)
+                        .date(date)
+                        .quantity(room.getNumberOfRoom())
+                        .build();
+                    stockRepository.save(stock);
+                }
+            }
+        }
+    }
+    private boolean stockExists(Room room, LocalDate date) {
+        return stockRepository.existsByRoomAndDate(room, date);
+    }
 }

--- a/src/main/java/com/fastcampus/mini9/common/util/schduler/StockService.java
+++ b/src/main/java/com/fastcampus/mini9/common/util/schduler/StockService.java
@@ -7,6 +7,7 @@ import com.fastcampus.mini9.domain.accommodation.repository.StockRepository;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +20,7 @@ public class StockService {
 
     private final StockRepository stockRepository;
 
+    @Async
     public void createStocks(LocalDate startDate, LocalDate endDate) {
         List<Room> rooms = roomRepository.findAll();
         for (Room room : rooms) {
@@ -33,6 +35,7 @@ public class StockService {
         }
     }
 
+    @Async
     public void createStocks(LocalDate startDate) {
         LocalDate endDate = startDate.plusDays(1);
         List<Room> rooms = roomRepository.findAll();

--- a/src/main/java/com/fastcampus/mini9/common/util/schduler/StockService.java
+++ b/src/main/java/com/fastcampus/mini9/common/util/schduler/StockService.java
@@ -32,6 +32,7 @@ public class StockService {
             }
         }
     }
+
     public void createStocks(LocalDate startDate) {
         LocalDate endDate = startDate.plusDays(1);
         List<Room> rooms = roomRepository.findAll();
@@ -48,7 +49,12 @@ public class StockService {
             }
         }
     }
+
     private boolean stockExists(Room room, LocalDate date) {
         return stockRepository.existsByRoomAndDate(room, date);
+    }
+
+    public void deleteBeforeStock(LocalDate date) {
+        stockRepository.deleteStocksBeforeDate(date);
     }
 }

--- a/src/main/java/com/fastcampus/mini9/common/util/schduler/StockService.java
+++ b/src/main/java/com/fastcampus/mini9/common/util/schduler/StockService.java
@@ -1,0 +1,35 @@
+package com.fastcampus.mini9.common.util.schduler;
+
+import com.fastcampus.mini9.domain.accommodation.entity.room.Room;
+import com.fastcampus.mini9.domain.accommodation.entity.room.Stock;
+import com.fastcampus.mini9.domain.accommodation.repository.RoomRepository;
+import com.fastcampus.mini9.domain.accommodation.repository.StockRepository;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class StockService {
+
+    private final RoomRepository roomRepository;
+
+    private final StockRepository stockRepository;
+
+    public void createStocks(LocalDate startDate, LocalDate endDate) {
+        List<Room> rooms = roomRepository.findAll();
+        for (Room room : rooms) {
+            for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
+                Stock stock = Stock.builder()
+                    .room(room)
+                    .date(date)
+                    .quantity(room.getNumberOfRoom())
+                    .build();
+                stockRepository.save(stock);
+            }
+        }
+    }
+}

--- a/src/main/java/com/fastcampus/mini9/common/util/schduler/StockService.java
+++ b/src/main/java/com/fastcampus/mini9/common/util/schduler/StockService.java
@@ -23,22 +23,18 @@ public class StockService {
     @Async
     public void createStocks(LocalDate startDate, LocalDate endDate) {
         List<Room> rooms = roomRepository.findAll();
-        rooms.parallelStream().forEach(room -> {
-            for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
-                createStockForDateWithoutExistsCheck(room, date);
-            }
-        });
+        rooms.parallelStream().forEach(room ->
+            startDate.datesUntil(endDate).forEach(date ->
+                createStockForDateWithoutExistsCheck(room, date)));
     }
 
     @Async
     public void createStocks(LocalDate startDate) {
         LocalDate endDate = startDate.plusDays(1);
         List<Room> rooms = roomRepository.findAll();
-        rooms.parallelStream().forEach(room -> {
-            for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
-                createStockForDate(room, date);
-            }
-        });
+        rooms.parallelStream().forEach(room ->
+            startDate.datesUntil(endDate).forEach(date ->
+                createStockForDate(room, date)));
     }
 
     @Async

--- a/src/main/java/com/fastcampus/mini9/domain/accommodation/entity/room/Stock.java
+++ b/src/main/java/com/fastcampus/mini9/domain/accommodation/entity/room/Stock.java
@@ -1,14 +1,14 @@
 package com.fastcampus.mini9.domain.accommodation.entity.room;
 
-import java.time.LocalDate;
-
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalDate;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -27,5 +27,12 @@ public class Stock {
 
 	private LocalDate date;
 
-	private int quantity;
+    private int quantity;
+
+    @Builder
+    public Stock(Room room, LocalDate date, int quantity) {
+        this.room = room;
+        this.date = date;
+        this.quantity = quantity;
+    }
 }

--- a/src/main/java/com/fastcampus/mini9/domain/accommodation/repository/StockRepository.java
+++ b/src/main/java/com/fastcampus/mini9/domain/accommodation/repository/StockRepository.java
@@ -1,0 +1,8 @@
+package com.fastcampus.mini9.domain.accommodation.repository;
+
+import com.fastcampus.mini9.domain.accommodation.entity.room.Stock;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StockRepository extends JpaRepository<Stock, Long> {
+
+}

--- a/src/main/java/com/fastcampus/mini9/domain/accommodation/repository/StockRepository.java
+++ b/src/main/java/com/fastcampus/mini9/domain/accommodation/repository/StockRepository.java
@@ -4,8 +4,15 @@ import com.fastcampus.mini9.domain.accommodation.entity.room.Room;
 import com.fastcampus.mini9.domain.accommodation.entity.room.Stock;
 import java.time.LocalDate;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface StockRepository extends JpaRepository<Stock, Long> {
 
     boolean existsByRoomAndDate(Room room, LocalDate date);
+
+    @Modifying
+    @Query("DELETE FROM Stock s WHERE s.date < :date")
+    void deleteStocksBeforeDate(@Param("date") LocalDate date);
 }

--- a/src/main/java/com/fastcampus/mini9/domain/accommodation/repository/StockRepository.java
+++ b/src/main/java/com/fastcampus/mini9/domain/accommodation/repository/StockRepository.java
@@ -1,8 +1,11 @@
 package com.fastcampus.mini9.domain.accommodation.repository;
 
+import com.fastcampus.mini9.domain.accommodation.entity.room.Room;
 import com.fastcampus.mini9.domain.accommodation.entity.room.Stock;
+import java.time.LocalDate;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StockRepository extends JpaRepository<Stock, Long> {
 
+    boolean existsByRoomAndDate(Room room, LocalDate date);
 }


### PR DESCRIPTION
서버를 킬 때 3개월 치 재고를 넣고,
매일 자정마다 3개월 뒤 하루치 재고 추가, 이전 날짜 재고 삭제로 스케줄링을 구현

처음 3개월치를 넣을 때는 DB 중복 체크를 하지 않고,
추후 매일 자정마다 넣을 때는 중복 체크를 하도록 설정해놨습니다.